### PR TITLE
BRD-184/batch-sync-error-handling

### DIFF
--- a/src/Adapters/PrestaShopAdapter.php
+++ b/src/Adapters/PrestaShopAdapter.php
@@ -36,7 +36,7 @@ class PrestaShopAdapter
                 $errors[] = [
                     'type' => 'transformation_error',
                     'product_index' => $index,
-                    'product_id' => $product['id'] ?? '',
+                    'product_id' => $product['remoteId'] ?? '',
                     'message' => $e->getMessage(),
                     'exception' => get_class($e),
                 ];

--- a/src/Adapters/PrestaShopAdapter.php
+++ b/src/Adapters/PrestaShopAdapter.php
@@ -293,6 +293,9 @@ class PrestaShopAdapter
             }
 
             foreach ($levelCategories as $category) {
+                if (!is_array($category)) {
+                    continue;
+                }
                 $this->extractCategory($category, $fieldName, $result);
             }
         }

--- a/src/Adapters/PrestaShopAdapter.php
+++ b/src/Adapters/PrestaShopAdapter.php
@@ -24,14 +24,29 @@ class PrestaShopAdapter
 
         $transformedProducts = [];
 
-        foreach ($prestaShopData['products'] as $product) {
+        $errors = [];
+
+        foreach ($prestaShopData['products'] as $index => $product) {
             if (!is_array($product)) {
                 continue;
             }
-            $transformedProducts[] = $this->transformProduct($product);
+            try {
+                $transformedProducts[] = $this->transformProduct($product);
+            } catch (\Exception $e) {
+                $errors[] = [
+                    'type' => 'transformation_error',
+                    'product_index' => $index,
+                    'product_id' => $product['id'] ?? '',
+                    'message' => $e->getMessage(),
+                    'exception' => get_class($e),
+                ];
+            }
         }
 
-        return $transformedProducts;
+        return [
+            'products' => $transformedProducts,
+            'errors' => $errors
+        ];
     }
 
     /**
@@ -407,7 +422,7 @@ class PrestaShopAdapter
         }
 
         $result = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
-        
+
         return $result;
     }
 }


### PR DESCRIPTION
https://invertus.atlassian.net/browse/BRD-184


Instead of failing the entire batch with an exception, if product transformation failed, just skip that product.



error if field is incorrect:

```
[2025-09-01 12:54:00] local.WARNING: Product transformation errors occurred {"application_id":"3bea2396-22f6-4fe3-8799-0367381c7892","chunk_offset":3,"errors_count":1,"errors":[{"type":"transformation_error","product_index":0,"product_id":"unknown","message":"Required field 'remoteId' is missing from PrestaShop data","exception":"BradSearch\\SyncSdk\\Exceptions\\ValidationException","timestamp":"2025-09-01 12:53:40"}]} 
```

Tried to update 500 products, batch was correct, and only 1 product failed:
```
[2025-09-01 12:54:00] local.INFO: Marked products as seen in session {"application_id":"3bea2396-22f6-4fe3-8799-0367381c7892","session_id":"sync_68b595db5f2db8.17774494","product_count":499,"updated_count":499,"created_count":0} 
```