### PR TITLE
Use structured update format with upsert support

### DIFF
--- a/src/V2/ValueObjects/BulkOperations/UpdateProductsPayload.php
+++ b/src/V2/ValueObjects/BulkOperations/UpdateProductsPayload.php
@@ -10,13 +10,15 @@ use BradSearch\SyncSdk\V2\ValueObjects\ValueObject;
 /**
  * Represents the payload for an update_products bulk operation.
  *
- * This immutable ValueObject contains flexible update arrays allowing partial updates.
- * Only the 'id' field is required in each update - all other fields are optional.
+ * Each update item has a structured format:
+ * - 'id' (required): Product identifier
+ * - 'fields' (required): Partial update fields (diff) applied to existing documents
+ * - 'upsert' (optional): Full document used to create the product when it doesn't exist in the index
  */
 final readonly class UpdateProductsPayload extends ValueObject
 {
     /**
-     * @param array<int, array<string, mixed>> $updates Array of update objects with flexible fields
+     * @param array<int, array{id: string, fields: array<string, mixed>, upsert?: array<string, mixed>}> $updates
      */
     public function __construct(
         public array $updates
@@ -27,7 +29,7 @@ final readonly class UpdateProductsPayload extends ValueObject
     /**
      * Returns a new instance with different updates.
      *
-     * @param array<int, array<string, mixed>> $updates
+     * @param array<int, array{id: string, fields: array<string, mixed>, upsert?: array<string, mixed>}> $updates
      */
     public function withUpdates(array $updates): self
     {
@@ -37,7 +39,7 @@ final readonly class UpdateProductsPayload extends ValueObject
     /**
      * Returns a new instance with an added update.
      *
-     * @param array<string, mixed> $update
+     * @param array{id: string, fields: array<string, mixed>, upsert?: array<string, mixed>} $update
      */
     public function withAddedUpdate(array $update): self
     {
@@ -83,6 +85,14 @@ final readonly class UpdateProductsPayload extends ValueObject
             if (!isset($update['id']) || $update['id'] === '' || $update['id'] === null) {
                 throw new InvalidArgumentException(
                     sprintf('Update at index %d must contain a non-empty "id" field.', $index),
+                    'updates',
+                    $update
+                );
+            }
+
+            if (!isset($update['fields']) || !is_array($update['fields'])) {
+                throw new InvalidArgumentException(
+                    sprintf('Update at index %d must contain a "fields" array with partial update data.', $index),
                     'updates',
                     $update
                 );

--- a/tests/V2/ValueObjects/BulkOperations/BulkOperationTest.php
+++ b/tests/V2/ValueObjects/BulkOperations/BulkOperationTest.php
@@ -232,8 +232,8 @@ class BulkOperationTest extends TestCase
     public function testUpdateProductsFactoryMethod(): void
     {
         $updates = [
-            ['id' => '123', 'price' => 29.99],
-            ['id' => '456', 'stock' => 50],
+            ['id' => '123', 'fields' => ['price' => 29.99]],
+            ['id' => '456', 'fields' => ['stock' => 50]],
         ];
         $operation = BulkOperation::updateProducts($updates);
 
@@ -245,16 +245,16 @@ class BulkOperationTest extends TestCase
     public function testUpdateProductsJsonSerialize(): void
     {
         $operation = BulkOperation::updateProducts([
-            ['id' => '123', 'price' => 29.99],
-            ['id' => '456', 'name' => 'Updated Product'],
+            ['id' => '123', 'fields' => ['price' => 29.99]],
+            ['id' => '456', 'fields' => ['name' => 'Updated Product']],
         ]);
 
         $expected = [
             'type' => 'update_products',
             'payload' => [
                 'updates' => [
-                    ['id' => '123', 'price' => 29.99],
-                    ['id' => '456', 'name' => 'Updated Product'],
+                    ['id' => '123', 'fields' => ['price' => 29.99]],
+                    ['id' => '456', 'fields' => ['name' => 'Updated Product']],
                 ],
             ],
         ];
@@ -265,7 +265,7 @@ class BulkOperationTest extends TestCase
     public function testWithPayloadAcceptsUpdateProductsPayload(): void
     {
         $operation = $this->createOperation();
-        $updatePayload = new UpdateProductsPayload([['id' => '1', 'price' => 19.99]]);
+        $updatePayload = new UpdateProductsPayload([['id' => '1', 'fields' => ['price' => 19.99]]]);
         $newOperation = $operation->withPayload($updatePayload);
 
         $this->assertNotSame($operation, $newOperation);
@@ -274,7 +274,7 @@ class BulkOperationTest extends TestCase
 
     public function testConstructorAcceptsUpdateProductsPayload(): void
     {
-        $payload = new UpdateProductsPayload([['id' => '1', 'price' => 19.99]]);
+        $payload = new UpdateProductsPayload([['id' => '1', 'fields' => ['price' => 19.99]]]);
         $operation = new BulkOperation(
             BulkOperationType::UPDATE_PRODUCTS,
             $payload

--- a/tests/V2/ValueObjects/BulkOperations/UpdateProductsPayloadTest.php
+++ b/tests/V2/ValueObjects/BulkOperations/UpdateProductsPayloadTest.php
@@ -12,32 +12,36 @@ use PHPUnit\Framework\TestCase;
 
 class UpdateProductsPayloadTest extends TestCase
 {
-    public function testConstructorWithPartialFields(): void
+    public function testConstructorWithStructuredUpdates(): void
     {
         $payload = new UpdateProductsPayload([
-            ['id' => '123', 'price' => 29.99],
-            ['id' => '456', 'name' => 'Updated Product'],
+            ['id' => '123', 'fields' => ['price' => 29.99]],
+            ['id' => '456', 'fields' => ['name' => 'Updated Product']],
         ]);
 
         $this->assertCount(2, $payload->updates);
         $this->assertEquals('123', $payload->updates[0]['id']);
-        $this->assertEquals(29.99, $payload->updates[0]['price']);
+        $this->assertEquals(['price' => 29.99], $payload->updates[0]['fields']);
     }
 
-    public function testConstructorWithSingleUpdate(): void
+    public function testConstructorWithUpsertData(): void
     {
         $payload = new UpdateProductsPayload([
-            ['id' => 'prod-123', 'stock' => 50],
+            [
+                'id' => '123',
+                'fields' => ['price' => 29.99],
+                'upsert' => ['id' => '123', 'name' => 'Full Product', 'price' => 29.99],
+            ],
         ]);
 
         $this->assertCount(1, $payload->updates);
-        $this->assertEquals('prod-123', $payload->updates[0]['id']);
+        $this->assertEquals('Full Product', $payload->updates[0]['upsert']['name']);
     }
 
     public function testExtendsValueObject(): void
     {
         $payload = new UpdateProductsPayload([
-            ['id' => '123', 'price' => 29.99],
+            ['id' => '123', 'fields' => ['price' => 29.99]],
         ]);
 
         $this->assertInstanceOf(ValueObject::class, $payload);
@@ -46,7 +50,7 @@ class UpdateProductsPayloadTest extends TestCase
     public function testImplementsJsonSerializable(): void
     {
         $payload = new UpdateProductsPayload([
-            ['id' => '123', 'price' => 29.99],
+            ['id' => '123', 'fields' => ['price' => 29.99]],
         ]);
 
         $this->assertInstanceOf(JsonSerializable::class, $payload);
@@ -55,8 +59,8 @@ class UpdateProductsPayloadTest extends TestCase
     public function testJsonSerialize(): void
     {
         $updates = [
-            ['id' => '123', 'price' => 29.99],
-            ['id' => '456', 'stock' => 100],
+            ['id' => '123', 'fields' => ['price' => 29.99]],
+            ['id' => '456', 'fields' => ['stock' => 100]],
         ];
 
         $payload = new UpdateProductsPayload($updates);
@@ -71,7 +75,7 @@ class UpdateProductsPayloadTest extends TestCase
     public function testToArrayReturnsJsonSerializeOutput(): void
     {
         $payload = new UpdateProductsPayload([
-            ['id' => '123', 'price' => 29.99],
+            ['id' => '123', 'fields' => ['price' => 29.99]],
         ]);
 
         $this->assertEquals($payload->jsonSerialize(), $payload->toArray());
@@ -80,8 +84,8 @@ class UpdateProductsPayloadTest extends TestCase
     public function testJsonEncodeProducesValidJson(): void
     {
         $payload = new UpdateProductsPayload([
-            ['id' => '123', 'price' => 29.99],
-            ['id' => '456', 'stock' => 50],
+            ['id' => '123', 'fields' => ['price' => 29.99]],
+            ['id' => '456', 'fields' => ['stock' => 50], 'upsert' => ['id' => '456', 'name' => 'Product']],
         ]);
 
         $json = json_encode($payload);
@@ -89,17 +93,19 @@ class UpdateProductsPayloadTest extends TestCase
 
         $this->assertArrayHasKey('updates', $decoded);
         $this->assertCount(2, $decoded['updates']);
+        $this->assertArrayHasKey('fields', $decoded['updates'][0]);
+        $this->assertArrayHasKey('upsert', $decoded['updates'][1]);
     }
 
     public function testWithUpdatesReturnsNewInstance(): void
     {
         $payload = new UpdateProductsPayload([
-            ['id' => '1', 'price' => 19.99],
+            ['id' => '1', 'fields' => ['price' => 19.99]],
         ]);
 
         $newPayload = $payload->withUpdates([
-            ['id' => '2', 'price' => 29.99],
-            ['id' => '3', 'price' => 39.99],
+            ['id' => '2', 'fields' => ['price' => 29.99]],
+            ['id' => '3', 'fields' => ['price' => 39.99]],
         ]);
 
         $this->assertNotSame($payload, $newPayload);
@@ -110,10 +116,10 @@ class UpdateProductsPayloadTest extends TestCase
     public function testWithAddedUpdateReturnsNewInstance(): void
     {
         $payload = new UpdateProductsPayload([
-            ['id' => '1', 'price' => 19.99],
+            ['id' => '1', 'fields' => ['price' => 19.99]],
         ]);
 
-        $newPayload = $payload->withAddedUpdate(['id' => '2', 'stock' => 50]);
+        $newPayload = $payload->withAddedUpdate(['id' => '2', 'fields' => ['stock' => 50]]);
 
         $this->assertNotSame($payload, $newPayload);
         $this->assertCount(1, $payload->updates);
@@ -135,7 +141,7 @@ class UpdateProductsPayloadTest extends TestCase
         $this->expectExceptionMessage('Update at index 0 must contain a non-empty "id" field.');
 
         new UpdateProductsPayload([
-            ['price' => 29.99],  // Missing 'id'
+            ['fields' => ['price' => 29.99]],
         ]);
     }
 
@@ -145,7 +151,7 @@ class UpdateProductsPayloadTest extends TestCase
         $this->expectExceptionMessage('Update at index 0 must contain a non-empty "id" field.');
 
         new UpdateProductsPayload([
-            ['id' => '', 'price' => 29.99],
+            ['id' => '', 'fields' => ['price' => 29.99]],
         ]);
     }
 
@@ -155,7 +161,7 @@ class UpdateProductsPayloadTest extends TestCase
         $this->expectExceptionMessage('Update at index 0 must contain a non-empty "id" field.');
 
         new UpdateProductsPayload([
-            ['id' => null, 'price' => 29.99],
+            ['id' => null, 'fields' => ['price' => 29.99]],
         ]);
     }
 
@@ -165,6 +171,26 @@ class UpdateProductsPayloadTest extends TestCase
         $this->expectExceptionMessage('Update at index 0 must be an array.');
 
         new UpdateProductsPayload(['not-an-array']);
+    }
+
+    public function testThrowsExceptionWhenFieldsMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Update at index 0 must contain a "fields" array');
+
+        new UpdateProductsPayload([
+            ['id' => '123'],
+        ]);
+    }
+
+    public function testThrowsExceptionWhenFieldsNotArray(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Update at index 0 must contain a "fields" array');
+
+        new UpdateProductsPayload([
+            ['id' => '123', 'fields' => 'not-an-array'],
+        ]);
     }
 
     public function testExceptionContainsArgumentName(): void
@@ -177,31 +203,10 @@ class UpdateProductsPayloadTest extends TestCase
         }
     }
 
-    public function testAcceptsFlexibleFieldsInUpdates(): void
-    {
-        $payload = new UpdateProductsPayload([
-            ['id' => '123', 'price' => 29.99, 'custom_field' => 'value', 'nested' => ['data' => true]],
-        ]);
-
-        $this->assertCount(1, $payload->updates);
-        $this->assertEquals('value', $payload->updates[0]['custom_field']);
-        $this->assertEquals(['data' => true], $payload->updates[0]['nested']);
-    }
-
-    public function testOnlyIdIsRequiredOtherFieldsOptional(): void
-    {
-        $payload = new UpdateProductsPayload([
-            ['id' => '123'],  // Only id, no other fields
-        ]);
-
-        $this->assertCount(1, $payload->updates);
-        $this->assertEquals('123', $payload->updates[0]['id']);
-    }
-
     public function testWithUpdatesValidatesItems(): void
     {
         $payload = new UpdateProductsPayload([
-            ['id' => '1', 'price' => 19.99],
+            ['id' => '1', 'fields' => ['price' => 19.99]],
         ]);
 
         $this->expectException(InvalidArgumentException::class);
@@ -213,12 +218,12 @@ class UpdateProductsPayloadTest extends TestCase
     public function testWithAddedUpdateValidatesMissingId(): void
     {
         $payload = new UpdateProductsPayload([
-            ['id' => '1', 'price' => 19.99],
+            ['id' => '1', 'fields' => ['price' => 19.99]],
         ]);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Update at index 1 must contain a non-empty "id" field.');
 
-        $payload->withAddedUpdate(['price' => 29.99]);
+        $payload->withAddedUpdate(['fields' => ['price' => 29.99]]);
     }
 }


### PR DESCRIPTION
## Summary

Replace the flat map update format with an explicit structured format for `UpdateProductsPayload`:

**Before** (flat — fields mixed with id at top level):
```json
{"updates": [{"id": "123", "price": 29.99}]}
```

**After** (structured — clear separation of concerns):
```json
{"updates": [{"id": "123", "fields": {"price": 29.99}, "upsert": {"id": "123", "name": "...", ...}}]}
```

- `id` (required): Product identifier
- `fields` (required): Partial update data (diff) — becomes OpenSearch `doc`
- `upsert` (optional): Full document for insert-if-missing — becomes OpenSearch `upsert`

## Context

This enables OpenSearch upsert support for products that exist in PostgreSQL but are missing from the search index (e.g. after V2 migration). Without this, partial updates fail silently with `document_missing_exception`.

**Part of:** Invertus/brad-search#307, Invertus/brad-app#424

## Test plan

- [x] `UpdateProductsPayloadTest` — validates structured format, required `fields`, optional `upsert`
- [x] `BulkOperationTest` — factory methods use new format
- [x] All 1471 SDK tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)