### PR TITLE
BRD-978-replace gid-with-name-slugs

### DIFF
--- a/examples/shopify-sync.php
+++ b/examples/shopify-sync.php
@@ -43,6 +43,10 @@ $shopifyGraphQLResponse = [
                         'vendor' => 'Nike',
                         'productType' => 'Shoes',
                         'tags' => ['Running', 'Athletic', 'Men'],
+                        'options' => [
+                            ['id' => 'gid://shopify/ProductOption/9001', 'name' => 'Size', 'values' => ['10', '11', '12']],
+                            ['id' => 'gid://shopify/ProductOption/9002', 'name' => 'Color', 'values' => ['Blue', 'Red']],
+                        ],
                         'createdAt' => '2024-01-15T10:30:00Z',
                         'updatedAt' => '2024-01-20T15:45:00Z',
                         'publishedAt' => '2024-01-15T12:00:00Z',

--- a/src/Adapters/README.md
+++ b/src/Adapters/README.md
@@ -203,7 +203,7 @@ $syncSdk->syncBulk('my-index', $transformedData['products']);
 | `variants[0].sku` | `sku` | First variant SKU |
 | `variants.*.availableForSale` | `inStock` | Any variant available |
 | `images.edges[*]` | `imageUrl` | Intelligently selects images by width: smallest for `small`, middle-range for `medium` |
-| `variants.selectedOptions` | `variants.attributes` | Attribute names lowercased (e.g., 'Size' → 'size') |
+| `variants.selectedOptions` | `variants.attrs` / `variants.attributes` | Keyed by a slug derived from the option name (Unicode-safe, lowercase, dash-joined). Shopify assigns a unique GID per product for the same option, so GIDs cannot be used as a shared key. |
 
 ### Shopify-Specific Transformations
 
@@ -217,6 +217,9 @@ $syncSdk->syncBulk('my-index', $transformedData['products']);
 ```
 
 #### Variants with Selected Options
+
+Option keys are slugged from `selectedOptions[].name`. The Shopify `ProductOption` GID is ignored on purpose — it is per-product, so using it would create a separate Elasticsearch field for every product's "Color" option.
+
 ```php
 // Shopify input
 "variants": {
@@ -234,7 +237,7 @@ $syncSdk->syncBulk('my-index', $transformedData['products']);
     ]
 }
 
-// BradSearch output
+// BradSearch output (without locales)
 "variants": [
     {
         "id": "123",
@@ -243,6 +246,18 @@ $syncSdk->syncBulk('my-index', $transformedData['products']);
             {"name": "size", "value": "42"},
             {"name": "color", "value": "Blue"}
         ]
+    }
+]
+
+// BradSearch output (with locales ['en', 'lt'])
+"variants": [
+    {
+        "id": "123",
+        "sku": "SHOE-BLU-42",
+        "attrs": {
+            "size":  {"en": "42", "lt": "42"},
+            "color": {"en": "Blue", "lt": "Blue"}
+        }
     }
 ]
 ```

--- a/src/Adapters/ShopifyAdapter.php
+++ b/src/Adapters/ShopifyAdapter.php
@@ -8,6 +8,9 @@ use BradSearch\SyncSdk\Exceptions\ValidationException;
 
 class ShopifyAdapter
 {
+    /** @var array<string, string> memoized option-name slugs */
+    private array $optionSlugCache = [];
+
     public function __construct()
     {
         if (!function_exists('bccomp')) {
@@ -458,13 +461,6 @@ class ShopifyAdapter
     }
 
     /**
-     * Transform variant selectedOptions to locale-keyed attrs format.
-     *
-     * Keys are slugs derived from option names (not Shopify GIDs), because
-     * Shopify assigns a unique GID per product for the same option concept.
-     * The slug rule must match bradsearch-shopify-app1 AttributesController::slugify()
-     * so document keys align with the Elasticsearch mapping keys.
-     *
      * Output: {"color": {"en-US": "White", "lt-LT": "White"}}
      *
      * @return array<string, array<string, string>>
@@ -498,15 +494,24 @@ class ShopifyAdapter
     }
 
     /**
-     * Derive a stable, Unicode-safe slug from an option name.
-     * Mirror of bradsearch-shopify-app1 AttributesController::slugify() — both
-     * repos must use an identical rule or mapping and documents will drift.
+     * Must match byte-for-byte:
+     *   bradsearch-shopify-app1 app/Http/Controllers/API/AttributesController.php::slugify()
+     * See docs/SLUG_RULE.md in that repo.
+     *
+     * Memoized per adapter instance: one compute per unique option name,
+     * not per variant × option. Cache is pure (slug is a deterministic
+     * function of name), so cross-product reuse within a sync is safe.
      */
     private function slugifyOptionName(string $name): string
     {
-        $slug = preg_replace('/[^\p{L}\p{N}]+/u', '-', mb_strtolower(trim($name), 'UTF-8'));
+        if (isset($this->optionSlugCache[$name])) {
+            return $this->optionSlugCache[$name];
+        }
 
-        return trim((string) $slug, '-');
+        $slug = preg_replace('/[^\p{L}\p{N}]+/u', '-', mb_strtolower(trim($name), 'UTF-8'));
+        $slug = trim((string) $slug, '-');
+
+        return $this->optionSlugCache[$name] = $slug === '' ? 'unknown' : $slug;
     }
 
     /**

--- a/src/Adapters/ShopifyAdapter.php
+++ b/src/Adapters/ShopifyAdapter.php
@@ -459,6 +459,12 @@ class ShopifyAdapter
 
     /**
      * Transform variant selectedOptions to locale-keyed attrs format.
+     *
+     * Keys are slugs derived from option names (not Shopify GIDs), because
+     * Shopify assigns a unique GID per product for the same option concept.
+     * The slug rule must match bradsearch-shopify-app1 AttributesController::slugify()
+     * so document keys align with the Elasticsearch mapping keys.
+     *
      * Output: {"color": {"en-US": "White", "lt-LT": "White"}}
      *
      * @return array<string, array<string, string>>
@@ -469,7 +475,7 @@ class ShopifyAdapter
 
         $result = [];
         foreach ($validOptions as $option) {
-            $result[strtolower($option['name'])] = array_fill_keys($locales, $option['value']);
+            $result[$this->slugifyOptionName($option['name'])] = array_fill_keys($locales, $option['value']);
         }
 
         return $result;
@@ -483,9 +489,24 @@ class ShopifyAdapter
     private function transformVariantOptions(array $selectedOptions): array
     {
         return array_values(array_map(
-            fn($option) => ['name' => strtolower($option['name']), 'value' => $option['value']],
+            fn($option) => [
+                'name' => $this->slugifyOptionName($option['name']),
+                'value' => $option['value'],
+            ],
             array_filter($selectedOptions, $this->isValidOption(...))
         ));
+    }
+
+    /**
+     * Derive a stable, Unicode-safe slug from an option name.
+     * Mirror of bradsearch-shopify-app1 AttributesController::slugify() — both
+     * repos must use an identical rule or mapping and documents will drift.
+     */
+    private function slugifyOptionName(string $name): string
+    {
+        $slug = preg_replace('/[^\p{L}\p{N}]+/u', '-', mb_strtolower(trim($name), 'UTF-8'));
+
+        return trim((string) $slug, '-');
     }
 
     /**

--- a/tests/Adapters/ShopifyAdapterTest.php
+++ b/tests/Adapters/ShopifyAdapterTest.php
@@ -277,6 +277,10 @@ class ShopifyAdapterTest extends TestCase
     public function testVariantsUseAttrsFormatWithLocales(): void
     {
         $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+        $product['node']['options'] = [
+            ['id' => 'gid://shopify/ProductOption/1001', 'name' => 'Color', 'values' => ['White', 'Black']],
+            ['id' => 'gid://shopify/ProductOption/1002', 'name' => 'Size', 'values' => ['S', 'M', 'L']],
+        ];
         $product['node']['variants'] = [
             'edges' => [
                 [
@@ -306,6 +310,9 @@ class ShopifyAdapterTest extends TestCase
     public function testVariantsUseAttributesFormatWithoutLocales(): void
     {
         $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+        $product['node']['options'] = [
+            ['id' => 'gid://shopify/ProductOption/1001', 'name' => 'Color', 'values' => ['White', 'Black']],
+        ];
         $product['node']['variants'] = [
             'edges' => [
                 [
@@ -328,6 +335,116 @@ class ShopifyAdapterTest extends TestCase
         $this->assertArrayHasKey('attributes', $variant);
         $this->assertArrayNotHasKey('attrs', $variant);
         $this->assertEquals([['name' => 'color', 'value' => 'White']], $variant['attributes']);
+    }
+
+    public function testVariantAttrsUseSlugKeyWhenProductOptionsAbsent(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+        // No product-level options field; slug is derived from selectedOptions[].name
+        $product['node']['variants'] = [
+            'edges' => [
+                [
+                    'node' => [
+                        'id' => 'gid://shopify/ProductVariant/100',
+                        'sku' => 'SNO-001',
+                        'selectedOptions' => [
+                            ['name' => 'Color', 'value' => 'White'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $data = $this->makeShopifyResponse([$product], 'en');
+
+        $result = $this->adapter->transform($data, ['en']);
+
+        $variant = $result['products'][0]['variants'][0];
+        $this->assertEquals(['en' => 'White'], $variant['attrs']['color']);
+    }
+
+    /**
+     * Two products with different per-product option GIDs but the same option
+     * name must collapse to the same slug key. This is the invariant the
+     * shared Elasticsearch mapping relies on to avoid field explosion.
+     */
+    public function testSameOptionNameAcrossProductsCollapsesToSingleSlug(): void
+    {
+        $productA = $this->makeProduct('gid://shopify/Product/1', 'A', 'Desc', 'BrandX', 'Sports');
+        $productA['node']['options'] = [
+            ['id' => 'gid://shopify/ProductOption/111', 'name' => 'Color', 'values' => ['Red']],
+        ];
+        $productA['node']['variants'] = [
+            'edges' => [[
+                'node' => [
+                    'id' => 'gid://shopify/ProductVariant/11',
+                    'sku' => 'A-1',
+                    'selectedOptions' => [['name' => 'Color', 'value' => 'Red']],
+                ],
+            ]],
+        ];
+
+        $productB = $this->makeProduct('gid://shopify/Product/2', 'B', 'Desc', 'BrandX', 'Sports');
+        $productB['node']['options'] = [
+            ['id' => 'gid://shopify/ProductOption/999', 'name' => 'Color', 'values' => ['Blue']],
+        ];
+        $productB['node']['variants'] = [
+            'edges' => [[
+                'node' => [
+                    'id' => 'gid://shopify/ProductVariant/22',
+                    'sku' => 'B-1',
+                    'selectedOptions' => [['name' => 'Color', 'value' => 'Blue']],
+                ],
+            ]],
+        ];
+
+        $data = $this->makeShopifyResponse([$productA, $productB], 'en');
+
+        $result = $this->adapter->transform($data, ['en']);
+
+        $variantA = $result['products'][0]['variants'][0];
+        $variantB = $result['products'][1]['variants'][0];
+
+        $this->assertEquals(['en' => 'Red'], $variantA['attrs']['color']);
+        $this->assertEquals(['en' => 'Blue'], $variantB['attrs']['color']);
+        $this->assertArrayNotHasKey('gid://shopify/ProductOption/111', $variantA['attrs']);
+        $this->assertArrayNotHasKey('gid://shopify/ProductOption/999', $variantB['attrs']);
+    }
+
+    /**
+     * Slug rule must be Unicode-safe and produce lowercase dash-joined keys.
+     * Must match bradsearch-shopify-app1 AttributesController::slugify().
+     */
+    public function testSlugifiesMultiWordAndUnicodeOptionNames(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+        $product['node']['options'] = [
+            ['id' => 'gid://shopify/ProductOption/1', 'name' => 'Shoe Size', 'values' => ['42']],
+            ['id' => 'gid://shopify/ProductOption/2', 'name' => 'Größe', 'values' => ['M']],
+            ['id' => 'gid://shopify/ProductOption/3', 'name' => 'Material / Fabric', 'values' => ['Cotton']],
+        ];
+        $product['node']['variants'] = [
+            'edges' => [[
+                'node' => [
+                    'id' => 'gid://shopify/ProductVariant/100',
+                    'sku' => 'SNO-001',
+                    'selectedOptions' => [
+                        ['name' => 'Shoe Size', 'value' => '42'],
+                        ['name' => 'Größe', 'value' => 'M'],
+                        ['name' => 'Material / Fabric', 'value' => 'Cotton'],
+                    ],
+                ],
+            ]],
+        ];
+
+        $data = $this->makeShopifyResponse([$product], 'en');
+
+        $result = $this->adapter->transform($data, ['en']);
+
+        $attrs = $result['products'][0]['variants'][0]['attrs'];
+        $this->assertArrayHasKey('shoe-size', $attrs);
+        $this->assertArrayHasKey('größe', $attrs);
+        $this->assertArrayHasKey('material-fabric', $attrs);
     }
 
     // ─── Product URL ───

--- a/tests/Adapters/ShopifyAdapterTest.php
+++ b/tests/Adapters/ShopifyAdapterTest.php
@@ -412,6 +412,39 @@ class ShopifyAdapterTest extends TestCase
     }
 
     /**
+     * Pathological option names made entirely of separators must not
+     * produce an empty key. Must fall back to "unknown" to match
+     * bradsearch-shopify-app1 AttributesController::slugify().
+     */
+    public function testSlugifyAllNonAlphanumericOptionNameDoesNotProduceEmptyKey(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+        $product['node']['options'] = [
+            ['id' => 'gid://shopify/ProductOption/1', 'name' => '---', 'values' => ['x']],
+        ];
+        $product['node']['variants'] = [
+            'edges' => [[
+                'node' => [
+                    'id' => 'gid://shopify/ProductVariant/100',
+                    'sku' => 'SNO-001',
+                    'selectedOptions' => [
+                        ['name' => '---', 'value' => 'x'],
+                    ],
+                ],
+            ]],
+        ];
+
+        $data = $this->makeShopifyResponse([$product], 'en');
+
+        $result = $this->adapter->transform($data, ['en']);
+
+        $attrs = $result['products'][0]['variants'][0]['attrs'];
+        $this->assertArrayNotHasKey('', $attrs);
+        $this->assertArrayHasKey('unknown', $attrs);
+        $this->assertEquals(['en' => 'x'], $attrs['unknown']);
+    }
+
+    /**
      * Slug rule must be Unicode-safe and produce lowercase dash-joined keys.
      * Must match bradsearch-shopify-app1 AttributesController::slugify().
      */


### PR DESCRIPTION
Fixing Elasticsearch field explosion on variant options and making feature search config human-readable.

[BRD-978](https://invertus.atlassian.net/browse/BRD-978)


[BRD-978]: https://invertus.atlassian.net/browse/BRD-978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ