### PR TITLE
Populate Shopify categoryDefault from Shopifys Standard Product Taxonomy

### DIFF
--- a/src/Adapters/ShopifyAdapter.php
+++ b/src/Adapters/ShopifyAdapter.php
@@ -107,12 +107,16 @@ class ShopifyAdapter
         $title = $this->getRequiredField($product, 'title');
         $description = $this->extractOptionalString($product, 'descriptionHtml', stripHtml: true);
         $brand = $this->extractOptionalString($product, 'vendor');
-        $categoryDefault = $this->extractOptionalString($product, 'productType');
+        $taxonomyCategory = $this->extractTaxonomyCategory($product);
+        $categoryIsTaxonomy = $taxonomyCategory !== '';
+        $categoryDefault = $categoryIsTaxonomy
+            ? $taxonomyCategory
+            : $this->extractOptionalString($product, 'productType');
         $productUrl = $this->extractProductUrl($product);
         $translations = $product['translations'] ?? [];
 
         $result += ! empty($locales)
-            ? $this->buildLocaleFields($locales, $primaryLocale, $translations, $product, $title, $description, $brand, $categoryDefault, $productUrl)
+            ? $this->buildLocaleFields($locales, $primaryLocale, $translations, $product, $title, $description, $brand, $categoryDefault, $productUrl, $categoryIsTaxonomy)
             : $this->buildPlainFields($title, $description, $brand, $categoryDefault, $productUrl, $product);
 
         if (isset($product['images']) && is_array($product['images'])) {
@@ -144,6 +148,7 @@ class ShopifyAdapter
         string $brand,
         string $categoryDefault,
         string $productUrl,
+        bool $categoryIsTaxonomy,
     ): array {
         $fields = [];
 
@@ -159,8 +164,11 @@ class ShopifyAdapter
                 $fields["description_{$locale}"] = $localeDescription;
             }
 
-            $translatedProductType = $this->translated($localeTranslations, 'product_type');
-            $localeCategoryDefault = $translatedProductType ?? $categoryDefault;
+            // Shopify's Standard Product Taxonomy is global English-only; never translate it.
+            // product_type translations only apply to the free-text productType fallback path.
+            $localeCategoryDefault = $categoryIsTaxonomy
+                ? $categoryDefault
+                : ($this->translated($localeTranslations, 'product_type') ?? $categoryDefault);
             $fields["categoryDefault_{$locale}"] = $localeCategoryDefault;
             $fields["categories_{$locale}"] = $this->buildCategories($localeCategoryDefault, $this->extractTags($product));
 
@@ -245,6 +253,39 @@ class ShopifyAdapter
         }
 
         return $stripHtml ? strip_tags($data[$field]) : $data[$field];
+    }
+
+    /**
+     * Extract a hierarchical category string from Shopify's Standard Product Taxonomy.
+     *
+     * Prefers `fullName` ("Apparel & Accessories > Clothing > Shirts") over `name` ("Shirts").
+     * Returns '' when the field is missing, malformed, or the "Uncategorized" literal —
+     * callers should fall back to the free-text `productType` in that case.
+     */
+    private function extractTaxonomyCategory(array $product): string
+    {
+        if (! isset($product['category']) || ! is_array($product['category'])) {
+            return '';
+        }
+
+        $category = $product['category'];
+
+        // Single global "Uncategorized" GID — treat as no category to avoid a junk facet bucket.
+        if (($category['id'] ?? null) === 'gid://shopify/TaxonomyCategory/na') {
+            return '';
+        }
+
+        $fullName = $category['fullName'] ?? null;
+        if (is_string($fullName) && $fullName !== '') {
+            return $fullName;
+        }
+
+        $name = $category['name'] ?? null;
+        if (is_string($name) && $name !== '') {
+            return $name;
+        }
+
+        return '';
     }
 
     /**

--- a/tests/Adapters/ShopifyAdapterTest.php
+++ b/tests/Adapters/ShopifyAdapterTest.php
@@ -480,6 +480,172 @@ class ShopifyAdapterTest extends TestCase
         $this->assertArrayHasKey('material-fabric', $attrs);
     }
 
+    // ─── Taxonomy category ───
+
+    public function testTaxonomyFullNameWinsOverProductType(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Tee', 'Desc', 'BrandX', 'Shoes');
+        $product['node']['category'] = [
+            'id' => 'gid://shopify/TaxonomyCategory/aa-1-13-8',
+            'name' => 'Shirts',
+            'fullName' => 'Apparel & Accessories > Clothing > Shirts',
+        ];
+
+        $data = $this->makeShopifyResponse([$product]);
+        $result = $this->adapter->transform($data);
+
+        $p = $result['products'][0];
+        $this->assertEquals('Apparel & Accessories > Clothing > Shirts', $p['categoryDefault']);
+        $this->assertContains('Apparel & Accessories > Clothing > Shirts', $p['categories']);
+        $this->assertNotContains('Shoes', $p['categories']);
+    }
+
+    public function testNullCategoryFallsBackToProductType(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Tee', 'Desc', 'BrandX', 'Shoes');
+        $product['node']['category'] = null;
+
+        $data = $this->makeShopifyResponse([$product]);
+        $result = $this->adapter->transform($data);
+
+        $this->assertEquals('Shoes', $result['products'][0]['categoryDefault']);
+    }
+
+    public function testUncategorizedGidTreatedAsMissing(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Tee', 'Desc', 'BrandX', 'Shoes');
+        $product['node']['category'] = [
+            'id' => 'gid://shopify/TaxonomyCategory/na',
+            'name' => 'Uncategorized',
+            'fullName' => 'Uncategorized',
+        ];
+
+        $data = $this->makeShopifyResponse([$product]);
+        $result = $this->adapter->transform($data);
+
+        $p = $result['products'][0];
+        $this->assertEquals('Shoes', $p['categoryDefault']);
+        $this->assertNotContains('Uncategorized', $p['categories']);
+    }
+
+    public function testCategoryAndProductTypeBothMissingEmitsEmptyString(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Tee', 'Desc', 'BrandX', '');
+        $product['node']['category'] = null;
+
+        $data = $this->makeShopifyResponse([$product]);
+        $result = $this->adapter->transform($data);
+
+        $p = $result['products'][0];
+        // Prior contract: empty string is emitted (not null/absent).
+        $this->assertArrayHasKey('categoryDefault', $p);
+        $this->assertSame('', $p['categoryDefault']);
+        $this->assertSame([], $p['categories']);
+    }
+
+    public function testTaxonomyWinsOverProductTypeTranslationInLocales(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Tee', 'Desc', 'BrandX', 'Shoes');
+        $product['node']['category'] = [
+            'id' => 'gid://shopify/TaxonomyCategory/aa-1-13-8',
+            'name' => 'Shirts',
+            'fullName' => 'Apparel & Accessories > Clothing > Shirts',
+        ];
+        $product['node']['translations'] = [
+            'lt-LT' => [
+                ['key' => 'product_type', 'value' => 'Batai'],
+            ],
+        ];
+
+        $data = $this->makeShopifyResponse([$product], 'en-US');
+        $result = $this->adapter->transform($data, ['en-US', 'lt-LT']);
+
+        $p = $result['products'][0];
+        // Taxonomy is English-only; same value across every locale regardless of product_type translation.
+        $this->assertEquals('Apparel & Accessories > Clothing > Shirts', $p['categoryDefault_en-US']);
+        $this->assertEquals('Apparel & Accessories > Clothing > Shirts', $p['categoryDefault_lt-LT']);
+        $this->assertNotEquals('Batai', $p['categoryDefault_lt-LT']);
+    }
+
+    public function testFallbackPathStillTranslatesProductTypeInLocales(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Tee', 'Desc', 'BrandX', 'Shoes');
+        $product['node']['category'] = null;
+        $product['node']['translations'] = [
+            'lt-LT' => [
+                ['key' => 'product_type', 'value' => 'Batai'],
+            ],
+        ];
+
+        $data = $this->makeShopifyResponse([$product], 'en-US');
+        $result = $this->adapter->transform($data, ['en-US', 'lt-LT']);
+
+        $p = $result['products'][0];
+        $this->assertEquals('Shoes', $p['categoryDefault_en-US']);
+        $this->assertEquals('Batai', $p['categoryDefault_lt-LT']);
+    }
+
+    public function testCategoriesArrayStaysConsistentAcrossSources(): void
+    {
+        // Taxonomy wins: categories = [fullName, ...tags]
+        $taxProduct = $this->makeProduct('gid://shopify/Product/1', 'Tee', 'Desc', 'BrandX', 'Shoes');
+        $taxProduct['node']['category'] = [
+            'id' => 'gid://shopify/TaxonomyCategory/aa-1-13-8',
+            'name' => 'Shirts',
+            'fullName' => 'Apparel & Accessories > Clothing > Shirts',
+        ];
+        $taxProduct['node']['tags'] = ['summer', 'cotton'];
+
+        // Fallback: categories = [productType, ...tags]
+        $fallbackProduct = $this->makeProduct('gid://shopify/Product/2', 'Ski', 'Desc', 'BrandX', 'Winter');
+        $fallbackProduct['node']['category'] = null;
+        $fallbackProduct['node']['tags'] = ['cold'];
+
+        // Both empty: categories = tags only
+        $emptyProduct = $this->makeProduct('gid://shopify/Product/3', 'Mystery', 'Desc', 'BrandX', '');
+        $emptyProduct['node']['category'] = null;
+        $emptyProduct['node']['tags'] = ['gift'];
+
+        $data = $this->makeShopifyResponse([$taxProduct, $fallbackProduct, $emptyProduct]);
+        $result = $this->adapter->transform($data);
+
+        [$a, $b, $c] = $result['products'];
+
+        $this->assertEquals('Apparel & Accessories > Clothing > Shirts', $a['categoryDefault']);
+        $this->assertEqualsCanonicalizing(
+            ['Apparel & Accessories > Clothing > Shirts', 'summer', 'cotton'],
+            $a['categories']
+        );
+
+        $this->assertEquals('Winter', $b['categoryDefault']);
+        $this->assertEqualsCanonicalizing(['Winter', 'cold'], $b['categories']);
+
+        $this->assertSame('', $c['categoryDefault']);
+        $this->assertEquals(['gift'], $c['categories']);
+    }
+
+    public function testMalformedCategoryFieldFallsThroughToProductType(): void
+    {
+        $cases = [
+            'string' => 'not-an-object',
+            'empty-array' => [],
+            'id-only' => ['id' => 'gid://shopify/TaxonomyCategory/aa-1-13-8'],
+            'non-string-names' => ['id' => 'gid://shopify/TaxonomyCategory/aa-1-13-8', 'name' => 42, 'fullName' => null],
+            'empty-names' => ['id' => 'gid://shopify/TaxonomyCategory/aa-1-13-8', 'name' => '', 'fullName' => ''],
+        ];
+
+        foreach ($cases as $label => $categoryValue) {
+            $product = $this->makeProduct('gid://shopify/Product/1', 'Tee', 'Desc', 'BrandX', 'Shoes');
+            $product['node']['category'] = $categoryValue;
+
+            $data = $this->makeShopifyResponse([$product]);
+            $result = $this->adapter->transform($data);
+
+            $this->assertEmpty($result['errors'], "case '{$label}' produced errors");
+            $this->assertEquals('Shoes', $result['products'][0]['categoryDefault'], "case '{$label}'");
+        }
+    }
+
     // ─── Product URL ───
 
     public function testProductUrlIncludedWhenPresent(): void


### PR DESCRIPTION
[BRD-993](https://invertus.atlassian.net/browse/BRD-993)

Populate Shopify categoryDefault from Shopify's Standard Product Taxonomy (category.fullName) instead of the free-text productType, with  productType kept as a fallback. Taxonomy IDs are global and stable, so coverage improves as merchants adopt standard categories; without the fallback, coverage would regress many greengoing products does not have categories so good fallback.                                                  
                                                                                                                                                  
<img width="774" height="330" alt="Screenshot 2026-04-21 at 12 22 23" src="https://github.com/user-attachments/assets/5c98bbca-fff2-4f89-8ffc-5e267e49c87f" />

image above shows the product type being helm while the category of some products is sporting goods below image shows table of products

<img width="1168" height="614" alt="Screenshot 2026-04-21 at 12 23 18" src="https://github.com/user-attachments/assets/5f973f93-cca1-4ccd-ab94-4749c44bea6d" />


[BRD-993]: https://invertus.atlassian.net/browse/BRD-993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ