### PR TITLE
BRD-1014-Add-Shopify-collections-facet-to-ShopifyAdapter

### DIFF
--- a/src/Adapters/ShopifyAdapter.php
+++ b/src/Adapters/ShopifyAdapter.php
@@ -209,8 +209,8 @@ class ShopifyAdapter
         string $categoryDefault,
         string $productUrl,
         array $product,
-        array $productCollections = [],
-        string $primaryLocale = 'en',
+        array $productCollections,
+        string $primaryLocale,
     ): array {
         $collections = $this->resolveCollectionTitles($productCollections, $primaryLocale, $primaryLocale);
 

--- a/src/Adapters/ShopifyAdapter.php
+++ b/src/Adapters/ShopifyAdapter.php
@@ -49,6 +49,8 @@ class ShopifyAdapter
 
         $primaryLocale = $shopifyData['locales']['primary'] ?? ($locales[0] ?? 'en');
 
+        $productCollectionsMap = $this->buildProductCollectionsMap($shopifyData['collections'] ?? []);
+
         $transformedProducts = [];
         $errors = [];
 
@@ -65,7 +67,7 @@ class ShopifyAdapter
             }
 
             try {
-                $transformedProducts[] = $this->transformProduct($edge['node'], $locales, $primaryLocale);
+                $transformedProducts[] = $this->transformProduct($edge['node'], $locales, $primaryLocale, $productCollectionsMap);
             } catch (\Throwable $e) {
                 $errors[] = [
                     'type' => 'transformation_error',
@@ -86,8 +88,9 @@ class ShopifyAdapter
      * @param array<string, mixed> $product Shopify product node (may include translations)
      * @param array<string> $locales Locale codes
      * @param string $primaryLocale Primary locale code
+     * @param array<string, array<int, array{default: string, translations: array<string, string>}>> $productCollectionsMap product-GID-keyed list of collection metadata entries
      */
-    private function transformProduct(array $product, array $locales, string $primaryLocale): array
+    private function transformProduct(array $product, array $locales, string $primaryLocale, array $productCollectionsMap = []): array
     {
         $price = $this->extractPrice($product);
         $basePrice = $this->extractBasePrice($product);
@@ -114,10 +117,12 @@ class ShopifyAdapter
             : $this->extractOptionalString($product, 'productType');
         $productUrl = $this->extractProductUrl($product);
         $translations = $product['translations'] ?? [];
+        $productGid = is_string($product['id'] ?? null) ? $product['id'] : '';
+        $productCollections = $productCollectionsMap[$productGid] ?? [];
 
         $result += ! empty($locales)
-            ? $this->buildLocaleFields($locales, $primaryLocale, $translations, $product, $title, $description, $brand, $categoryDefault, $productUrl, $categoryIsTaxonomy)
-            : $this->buildPlainFields($title, $description, $brand, $categoryDefault, $productUrl, $product);
+            ? $this->buildLocaleFields($locales, $primaryLocale, $translations, $product, $title, $description, $brand, $categoryDefault, $productUrl, $categoryIsTaxonomy, $productCollections)
+            : $this->buildPlainFields($title, $description, $brand, $categoryDefault, $productUrl, $product, $productCollections, $primaryLocale);
 
         if (isset($product['images']) && is_array($product['images'])) {
             $imageUrl = $this->extractImages($product['images']);
@@ -136,6 +141,7 @@ class ShopifyAdapter
     /**
      * Build locale-suffixed fields for all locales.
      *
+     * @param array<int, array{default: string, translations: array<string, string>}> $productCollections
      * @return array<string, mixed>
      */
     private function buildLocaleFields(
@@ -149,6 +155,7 @@ class ShopifyAdapter
         string $categoryDefault,
         string $productUrl,
         bool $categoryIsTaxonomy,
+        array $productCollections = [],
     ): array {
         $fields = [];
 
@@ -179,6 +186,11 @@ class ShopifyAdapter
             if ($productUrl !== '') {
                 $fields["productUrl_{$locale}"] = $productUrl;
             }
+
+            $localeCollections = $this->resolveCollectionTitles($productCollections, $locale, $primaryLocale);
+            if (!empty($localeCollections)) {
+                $fields["collections_{$locale}"] = $localeCollections;
+            }
         }
 
         return $fields;
@@ -187,6 +199,7 @@ class ShopifyAdapter
     /**
      * Build plain (non-localized) fields for backward compatibility.
      *
+     * @param array<int, array{default: string, translations: array<string, string>}> $productCollections
      * @return array<string, mixed>
      */
     private function buildPlainFields(
@@ -196,7 +209,11 @@ class ShopifyAdapter
         string $categoryDefault,
         string $productUrl,
         array $product,
+        array $productCollections = [],
+        string $primaryLocale = 'en',
     ): array {
+        $collections = $this->resolveCollectionTitles($productCollections, $primaryLocale, $primaryLocale);
+
         return array_filter([
             'name' => $title,
             'description' => $description !== '' ? $description : null,
@@ -204,7 +221,99 @@ class ShopifyAdapter
             'categoryDefault' => $categoryDefault,
             'categories' => $this->buildCategories($categoryDefault, $this->extractTags($product)),
             'productUrl' => $productUrl !== '' ? $productUrl : null,
+            'collections' => !empty($collections) ? $collections : null,
         ], fn($v) => $v !== null);
+    }
+
+    /**
+     * Invert raw collections metadata into a product-GID-keyed map. Each value is
+     * the list of collection-title entries (default + translations) for the
+     * collections that product belongs to.
+     *
+     * The connector emits each collection node with a `product_gids` array
+     * covering its full membership (paginated server-side), so this method is
+     * the single point at which the join is materialized.
+     *
+     * @param array<int, array<string, mixed>> $rawCollections
+     * @return array<string, array<int, array{default: string, translations: array<string, string>}>>
+     */
+    private function buildProductCollectionsMap(array $rawCollections): array
+    {
+        $map = [];
+
+        foreach ($rawCollections as $collection) {
+            if (!is_array($collection)) {
+                continue;
+            }
+
+            $defaultTitle = $collection['title'] ?? null;
+            if (!is_string($defaultTitle) || $defaultTitle === '') {
+                continue;
+            }
+
+            $translationsByLocale = [];
+            $rawTranslations = $collection['translations'] ?? [];
+            if (is_array($rawTranslations)) {
+                foreach ($rawTranslations as $locale => $entries) {
+                    if (!is_string($locale) || !is_array($entries)) {
+                        continue;
+                    }
+                    foreach ($entries as $entry) {
+                        if (is_array($entry)
+                            && ($entry['key'] ?? null) === 'title'
+                            && is_string($entry['value'] ?? null)
+                            && $entry['value'] !== ''
+                        ) {
+                            $translationsByLocale[$locale] = $entry['value'];
+                            break;
+                        }
+                    }
+                }
+            }
+
+            $entry = ['default' => $defaultTitle, 'translations' => $translationsByLocale];
+
+            $productGids = $collection['product_gids'] ?? [];
+            if (!is_array($productGids)) {
+                continue;
+            }
+
+            foreach ($productGids as $productGid) {
+                if (!is_string($productGid) || $productGid === '') {
+                    continue;
+                }
+                $map[$productGid][] = $entry;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Resolve titles for a product's collections in a given locale.
+     * Falls back to the default title when a translation is missing.
+     *
+     * @param array<int, array{default: string, translations: array<string, string>}> $productCollections
+     * @return array<string>
+     */
+    private function resolveCollectionTitles(array $productCollections, string $locale, string $primaryLocale): array
+    {
+        if (empty($productCollections)) {
+            return [];
+        }
+
+        $titles = [];
+        foreach ($productCollections as $entry) {
+            $title = $locale === $primaryLocale
+                ? $entry['default']
+                : ($entry['translations'][$locale] ?? $entry['default']);
+
+            if ($title !== '') {
+                $titles[] = $title;
+            }
+        }
+
+        return array_values(array_unique($titles));
     }
 
     /**

--- a/src/Adapters/ShopifyAdapter.php
+++ b/src/Adapters/ShopifyAdapter.php
@@ -259,7 +259,8 @@ class ShopifyAdapter
                         continue;
                     }
                     foreach ($entries as $entry) {
-                        if (is_array($entry)
+                        if (
+                            is_array($entry)
                             && ($entry['key'] ?? null) === 'title'
                             && is_string($entry['value'] ?? null)
                             && $entry['value'] !== ''

--- a/tests/Adapters/ShopifyAdapterTest.php
+++ b/tests/Adapters/ShopifyAdapterTest.php
@@ -876,6 +876,45 @@ class ShopifyAdapterTest extends TestCase
         $this->assertArrayNotHasKey('collections_en', $result['products'][1]);
     }
 
+    public function testTransformPlainModeEmitsCollectionsField(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+
+        $data = $this->makeShopifyResponse([$product], 'en');
+        $data['collections'] = [
+            [
+                'id' => 'gid://shopify/Collection/10',
+                'title' => 'Hyrogen',
+                'translations' => ['lt' => [['key' => 'title', 'value' => 'Hidrogenas']]],
+                'product_gids' => ['gid://shopify/Product/1'],
+            ],
+            [
+                'id' => 'gid://shopify/Collection/20',
+                'title' => 'Automated Collection',
+                'translations' => [],
+                'product_gids' => ['gid://shopify/Product/1'],
+            ],
+        ];
+
+        $result = $this->adapter->transform($data, []);
+        $product = $result['products'][0];
+
+        $this->assertEquals(['Hyrogen', 'Automated Collection'], $product['collections']);
+        $this->assertArrayNotHasKey('collections_en', $product);
+        $this->assertArrayNotHasKey('collections_lt', $product);
+    }
+
+    public function testTransformPlainModeOmitsCollectionsWhenAbsent(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+
+        $data = $this->makeShopifyResponse([$product], 'en');
+
+        $result = $this->adapter->transform($data, []);
+
+        $this->assertArrayNotHasKey('collections', $result['products'][0]);
+    }
+
     // ─── Helpers ───
 
     private function makeProduct(string $gid, string $title, string $description, string $vendor, string $productType): array

--- a/tests/Adapters/ShopifyAdapterTest.php
+++ b/tests/Adapters/ShopifyAdapterTest.php
@@ -808,6 +808,74 @@ class ShopifyAdapterTest extends TestCase
         $this->assertFalse($result['products'][0]['inStock']);
     }
 
+    // ─── Collections ───
+
+    public function testTransformWithCollectionsEmitsLocalizedFacet(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+
+        $data = $this->makeShopifyResponse([$product], 'en');
+        $data['collections'] = [
+            [
+                'id' => 'gid://shopify/Collection/10',
+                'title' => 'Hyrogen',
+                'translations' => ['lt' => [['key' => 'title', 'value' => 'Hidrogenas']]],
+                'product_gids' => ['gid://shopify/Product/1'],
+            ],
+            [
+                'id' => 'gid://shopify/Collection/20',
+                'title' => 'Automated Collection',
+                'translations' => [],
+                'product_gids' => ['gid://shopify/Product/1'],
+            ],
+            [
+                'id' => 'gid://shopify/Collection/30',
+                'title' => 'Other Collection',
+                'translations' => [],
+                'product_gids' => ['gid://shopify/Product/999'],
+            ],
+        ];
+
+        $result = $this->adapter->transform($data, ['en', 'lt']);
+        $product = $result['products'][0];
+
+        $this->assertEquals(['Hyrogen', 'Automated Collection'], $product['collections_en']);
+        $this->assertEquals(['Hidrogenas', 'Automated Collection'], $product['collections_lt']);
+    }
+
+    public function testTransformWithoutCollectionsMetadataOmitsField(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+
+        $data = $this->makeShopifyResponse([$product], 'en');
+
+        $result = $this->adapter->transform($data, ['en']);
+        $product = $result['products'][0];
+
+        $this->assertArrayNotHasKey('collections_en', $product);
+    }
+
+    public function testTransformOmitsCollectionsForProductNotListedInAnyCollection(): void
+    {
+        $productA = $this->makeProduct('gid://shopify/Product/1', 'A', 'Desc', 'BrandX', 'Sports');
+        $productB = $this->makeProduct('gid://shopify/Product/2', 'B', 'Desc', 'BrandX', 'Sports');
+
+        $data = $this->makeShopifyResponse([$productA, $productB], 'en');
+        $data['collections'] = [
+            [
+                'id' => 'gid://shopify/Collection/10',
+                'title' => 'Hyrogen',
+                'translations' => [],
+                'product_gids' => ['gid://shopify/Product/1'],
+            ],
+        ];
+
+        $result = $this->adapter->transform($data, ['en']);
+
+        $this->assertEquals(['Hyrogen'], $result['products'][0]['collections_en']);
+        $this->assertArrayNotHasKey('collections_en', $result['products'][1]);
+    }
+
     // ─── Helpers ───
 
     private function makeProduct(string $gid, string $title, string $description, string $vendor, string $productType): array


### PR DESCRIPTION
 Consumes the connector's new collections payload and emits collection titles as a localized facet field per product
  (collections_{locale}, or collections in plain mode), with translation fallback to the default title.

[BRD-1014](https://invertus.atlassian.net/browse/BRD-1014)

[BRD-1014]: https://invertus.atlassian.net/browse/BRD-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ