### PR TITLE
BRD-1002: Plumb similarity through SearchSettingsRequest

### DIFF
--- a/src/V2/ValueObjects/SearchSettings/SearchSettingsRequest.php
+++ b/src/V2/ValueObjects/SearchSettings/SearchSettingsRequest.php
@@ -26,6 +26,7 @@ final readonly class SearchSettingsRequest extends ValueObject
      * @param array<string>|null $supportedLocales Optional supported locales
      * @param array<string, mixed>|null $rawQueryConfig Optional raw query config (Go-native format, bypasses SearchConfig VOs)
      * @param array<string, mixed>|null $filterConfig Optional filter configuration for facets/aggregations
+     * @param string|null $similarity Optional similarity algorithm applied to text fields in the index mapping (e.g. "boolean")
      */
     public function __construct(
         public string $appId,
@@ -37,6 +38,7 @@ final readonly class SearchSettingsRequest extends ValueObject
         public ?array $filterConfig = null,
         public ?array $featuresKeyValueMap = null,
         public ?array $attributeKeyValueMap = null,
+        public ?string $similarity = null,
     ) {
         $this->validateAppId($appId);
         $this->supportedLocales = $supportedLocales;
@@ -60,6 +62,7 @@ final readonly class SearchSettingsRequest extends ValueObject
             filterConfig: $config['filter_config'] ?? null,
             featuresKeyValueMap: $config['features_key_value_map'] ?? null,
             attributeKeyValueMap: $config['attribute_key_value_map'] ?? null,
+            similarity: $config['similarity'] ?? null,
         );
     }
 
@@ -68,7 +71,7 @@ final readonly class SearchSettingsRequest extends ValueObject
      */
     public function withAppId(string $appId): self
     {
-        return new self($appId, $this->searchConfig, $this->scoringConfig, $this->responseConfig, $this->supportedLocales, $this->rawQueryConfig, $this->filterConfig, $this->featuresKeyValueMap, $this->attributeKeyValueMap);
+        return new self($appId, $this->searchConfig, $this->scoringConfig, $this->responseConfig, $this->supportedLocales, $this->rawQueryConfig, $this->filterConfig, $this->featuresKeyValueMap, $this->attributeKeyValueMap, $this->similarity);
     }
 
     /**
@@ -76,7 +79,7 @@ final readonly class SearchSettingsRequest extends ValueObject
      */
     public function withSearchConfig(?SearchConfig $searchConfig): self
     {
-        return new self($this->appId, $searchConfig, $this->scoringConfig, $this->responseConfig, $this->supportedLocales, $this->rawQueryConfig, $this->filterConfig, $this->featuresKeyValueMap, $this->attributeKeyValueMap);
+        return new self($this->appId, $searchConfig, $this->scoringConfig, $this->responseConfig, $this->supportedLocales, $this->rawQueryConfig, $this->filterConfig, $this->featuresKeyValueMap, $this->attributeKeyValueMap, $this->similarity);
     }
 
     /**
@@ -84,7 +87,7 @@ final readonly class SearchSettingsRequest extends ValueObject
      */
     public function withScoringConfig(?ScoringConfig $scoringConfig): self
     {
-        return new self($this->appId, $this->searchConfig, $scoringConfig, $this->responseConfig, $this->supportedLocales, $this->rawQueryConfig, $this->filterConfig, $this->featuresKeyValueMap, $this->attributeKeyValueMap);
+        return new self($this->appId, $this->searchConfig, $scoringConfig, $this->responseConfig, $this->supportedLocales, $this->rawQueryConfig, $this->filterConfig, $this->featuresKeyValueMap, $this->attributeKeyValueMap, $this->similarity);
     }
 
     /**
@@ -92,7 +95,15 @@ final readonly class SearchSettingsRequest extends ValueObject
      */
     public function withResponseConfig(?ResponseConfig $responseConfig): self
     {
-        return new self($this->appId, $this->searchConfig, $this->scoringConfig, $responseConfig, $this->supportedLocales, $this->rawQueryConfig, $this->filterConfig, $this->featuresKeyValueMap, $this->attributeKeyValueMap);
+        return new self($this->appId, $this->searchConfig, $this->scoringConfig, $responseConfig, $this->supportedLocales, $this->rawQueryConfig, $this->filterConfig, $this->featuresKeyValueMap, $this->attributeKeyValueMap, $this->similarity);
+    }
+
+    /**
+     * Returns a new instance with a different similarity setting.
+     */
+    public function withSimilarity(?string $similarity): self
+    {
+        return new self($this->appId, $this->searchConfig, $this->scoringConfig, $this->responseConfig, $this->supportedLocales, $this->rawQueryConfig, $this->filterConfig, $this->featuresKeyValueMap, $this->attributeKeyValueMap, $similarity);
     }
 
     /**
@@ -141,6 +152,10 @@ final readonly class SearchSettingsRequest extends ValueObject
 
         if ($this->attributeKeyValueMap !== null && count($this->attributeKeyValueMap) > 0) {
             $result['attribute_key_value_map'] = $this->attributeKeyValueMap;
+        }
+
+        if ($this->similarity !== null && $this->similarity !== '') {
+            $result['similarity'] = $this->similarity;
         }
 
         return $result;

--- a/src/V2/ValueObjects/SearchSettings/SearchSettingsRequestBuilder.php
+++ b/src/V2/ValueObjects/SearchSettings/SearchSettingsRequestBuilder.php
@@ -50,6 +50,8 @@ final class SearchSettingsRequestBuilder
     /** @var array<string, array<string, string>>|null */
     private ?array $attributeKeyValueMap = null;
 
+    private ?string $similarity = null;
+
     /**
      * Sets the application ID.
      */
@@ -200,6 +202,15 @@ final class SearchSettingsRequestBuilder
     }
 
     /**
+     * Sets the similarity algorithm applied to text fields in the index mapping.
+     */
+    public function similarity(string $similarity): self
+    {
+        $this->similarity = $similarity;
+        return $this;
+    }
+
+    /**
      * Sets the complete search config.
      */
     public function searchConfig(SearchConfig $searchConfig): self
@@ -293,6 +304,7 @@ final class SearchSettingsRequestBuilder
             $this->filterConfig,
             $this->featuresKeyValueMap,
             $this->attributeKeyValueMap,
+            $this->similarity,
         );
     }
 
@@ -314,6 +326,7 @@ final class SearchSettingsRequestBuilder
         $this->filterConfig = null;
         $this->featuresKeyValueMap = null;
         $this->attributeKeyValueMap = null;
+        $this->similarity = null;
         return $this;
     }
 }

--- a/tests/V2/ValueObjects/SearchSettings/SearchSettingsRequestBuilderTest.php
+++ b/tests/V2/ValueObjects/SearchSettings/SearchSettingsRequestBuilderTest.php
@@ -479,4 +479,27 @@ class SearchSettingsRequestBuilderTest extends TestCase
         $this->assertNotNull($request->searchConfig);
         $this->assertNull($request->responseConfig);
     }
+
+    public function testBuildWithSimilarity(): void
+    {
+        $builder = new SearchSettingsRequestBuilder();
+        $request = $builder
+            ->appId('app_123')
+            ->similarity('boolean')
+            ->build();
+
+        $this->assertEquals('boolean', $request->similarity);
+        $this->assertEquals('boolean', $request->jsonSerialize()['similarity']);
+    }
+
+    public function testResetClearsSimilarity(): void
+    {
+        $builder = new SearchSettingsRequestBuilder();
+        $builder->appId('app_123')->similarity('boolean');
+        $builder->reset();
+
+        $request = $builder->appId('app_456')->build();
+
+        $this->assertNull($request->similarity);
+    }
 }

--- a/tests/V2/ValueObjects/SearchSettings/SearchSettingsRequestTest.php
+++ b/tests/V2/ValueObjects/SearchSettings/SearchSettingsRequestTest.php
@@ -571,4 +571,92 @@ class SearchSettingsRequestTest extends TestCase
         $this->assertEquals(0.1, $serialized['scoring_config']['min_score']);
         $this->assertEquals('sales_count', $serialized['scoring_config']['function_score']['field']);
     }
+
+    public function testConstructorWithSimilarity(): void
+    {
+        $request = new SearchSettingsRequest('app_123', similarity: 'boolean');
+
+        $this->assertEquals('boolean', $request->similarity);
+    }
+
+    public function testSimilarityDefaultsToNull(): void
+    {
+        $request = new SearchSettingsRequest('app_123');
+
+        $this->assertNull($request->similarity);
+    }
+
+    public function testJsonSerializeIncludesSimilarity(): void
+    {
+        $request = new SearchSettingsRequest('app_123', similarity: 'boolean');
+        $serialized = $request->jsonSerialize();
+
+        $this->assertArrayHasKey('similarity', $serialized);
+        $this->assertEquals('boolean', $serialized['similarity']);
+    }
+
+    public function testJsonSerializeOmitsNullSimilarity(): void
+    {
+        $request = new SearchSettingsRequest('app_123');
+        $serialized = $request->jsonSerialize();
+
+        $this->assertArrayNotHasKey('similarity', $serialized);
+    }
+
+    public function testJsonSerializeOmitsEmptySimilarity(): void
+    {
+        $request = new SearchSettingsRequest('app_123', similarity: '');
+        $serialized = $request->jsonSerialize();
+
+        $this->assertArrayNotHasKey('similarity', $serialized);
+    }
+
+    public function testFromSearchConfigurationExtractsSimilarity(): void
+    {
+        $config = [
+            'supported_locales' => ['lt-LT'],
+            'similarity' => 'boolean',
+        ];
+
+        $request = SearchSettingsRequest::fromSearchConfiguration('app_123', $config);
+
+        $this->assertEquals('boolean', $request->similarity);
+    }
+
+    public function testFromSearchConfigurationHandlesMissingSimilarity(): void
+    {
+        $config = ['supported_locales' => ['lt-LT']];
+
+        $request = SearchSettingsRequest::fromSearchConfiguration('app_123', $config);
+
+        $this->assertNull($request->similarity);
+    }
+
+    public function testWithMethodsPreserveSimilarity(): void
+    {
+        $request = new SearchSettingsRequest('app_123', similarity: 'boolean');
+
+        $this->assertEquals('boolean', $request->withAppId('app_456')->similarity);
+        $this->assertEquals('boolean', $request->withSearchConfig(null)->similarity);
+        $this->assertEquals('boolean', $request->withScoringConfig(null)->similarity);
+        $this->assertEquals('boolean', $request->withResponseConfig(null)->similarity);
+    }
+
+    public function testWithSimilarityReturnsNewInstance(): void
+    {
+        $request = new SearchSettingsRequest('app_123');
+        $updated = $request->withSimilarity('boolean');
+
+        $this->assertNotSame($request, $updated);
+        $this->assertNull($request->similarity);
+        $this->assertEquals('boolean', $updated->similarity);
+    }
+
+    public function testWithSimilarityCanBeClearedToNull(): void
+    {
+        $request = new SearchSettingsRequest('app_123', similarity: 'boolean');
+        $cleared = $request->withSimilarity(null);
+
+        $this->assertNull($cleared->similarity);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds an optional `similarity` field to `SearchSettingsRequest` so callers can configure the index similarity algorithm (e.g. `"boolean"`).
- Threads it through the constructor, `fromSearchConfiguration()`, all `with*` mutators (plus a new `withSimilarity()`), `jsonSerialize()`, and `SearchSettingsRequestBuilder`.
- Without this, `similarity` set in the search configuration array is silently dropped before reaching the sync API.

## Test plan
- [x] New unit tests on `SearchSettingsRequest` covering constructor, `fromSearchConfiguration`, `jsonSerialize` (present/null/empty), `with*` preservation, and `withSimilarity()`.
- [x] New unit tests on `SearchSettingsRequestBuilder` covering `similarity()` and `reset()`.
- [x] Full test suite passes (1561 tests).
- [x] PHPStan clean on changed files.
- [x] PHPCS clean on changed files.

Jira task url: https://invertus.atlassian.net/browse/BRD-1002