### PR TITLE
BRD-1030-Localize-productUrl-per-locale-in-ShopifyAdapter

### DIFF
--- a/src/Adapters/ShopifyAdapter.php
+++ b/src/Adapters/ShopifyAdapter.php
@@ -116,12 +116,13 @@ class ShopifyAdapter
             ? $taxonomyCategory
             : $this->extractOptionalString($product, 'productType');
         $productUrl = $this->extractProductUrl($product);
+        $defaultHandle = $this->extractDefaultHandle($product, $productUrl);
         $translations = $product['translations'] ?? [];
         $productGid = is_string($product['id'] ?? null) ? $product['id'] : '';
         $productCollections = $productCollectionsMap[$productGid] ?? [];
 
         $result += ! empty($locales)
-            ? $this->buildLocaleFields($locales, $primaryLocale, $translations, $product, $title, $description, $brand, $categoryDefault, $productUrl, $categoryIsTaxonomy, $productCollections)
+            ? $this->buildLocaleFields($locales, $primaryLocale, $translations, $product, $title, $description, $brand, $categoryDefault, $productUrl, $defaultHandle, $categoryIsTaxonomy, $productCollections)
             : $this->buildPlainFields($title, $description, $brand, $categoryDefault, $productUrl, $product, $productCollections, $primaryLocale);
 
         if (isset($product['images']) && is_array($product['images'])) {
@@ -154,6 +155,7 @@ class ShopifyAdapter
         string $brand,
         string $categoryDefault,
         string $productUrl,
+        string $defaultHandle,
         bool $categoryIsTaxonomy,
         array $productCollections = [],
     ): array {
@@ -183,8 +185,15 @@ class ShopifyAdapter
             if ($brand !== '') {
                 $fields["brand_{$locale}"] = $brand;
             }
-            if ($productUrl !== '') {
-                $fields["productUrl_{$locale}"] = $productUrl;
+            $localeUrl = $this->buildLocaleProductUrl(
+                $productUrl,
+                $defaultHandle,
+                $this->translated($localeTranslations, 'handle'),
+                $locale,
+                $primaryLocale,
+            );
+            if ($localeUrl !== '') {
+                $fields["productUrl_{$locale}"] = $localeUrl;
             }
 
             $localeCollections = $this->resolveCollectionTitles($productCollections, $locale, $primaryLocale);
@@ -405,6 +414,79 @@ class ShopifyAdapter
     {
         return $this->extractOptionalString($product, 'onlineStoreUrl')
             ?: $this->extractOptionalString($product, 'onlineStorePreviewUrl');
+    }
+
+    /**
+     * Default handle preferred from the GraphQL `handle` field; otherwise parsed
+     * from the URL (last path segment after `/products/`) so older payloads and
+     * dev stores without `handle` still work.
+     */
+    private function extractDefaultHandle(array $product, string $productUrl): string
+    {
+        $handle = $this->extractOptionalString($product, 'handle');
+        if ($handle !== '') {
+            return $handle;
+        }
+
+        if ($productUrl === '') {
+            return '';
+        }
+
+        $path = parse_url($productUrl, PHP_URL_PATH);
+        if (!is_string($path) || $path === '') {
+            return '';
+        }
+
+        if (preg_match('~/products/([^/?#]+)~', $path, $m) === 1) {
+            return $m[1];
+        }
+
+        return '';
+    }
+
+    /**
+     * Build a per-locale product URL by injecting the locale prefix and the
+     * translated handle (when present). Falls back to the default handle and
+     * preserves the query string so dev-store preview tokens keep working.
+     */
+    private function buildLocaleProductUrl(
+        string $baseUrl,
+        string $defaultHandle,
+        ?string $translatedHandle,
+        string $locale,
+        string $primaryLocale,
+    ): string {
+        if ($baseUrl === '') {
+            return '';
+        }
+
+        $parsed = parse_url($baseUrl);
+        if (!is_array($parsed) || !isset($parsed['scheme'], $parsed['host'])) {
+            return $baseUrl;
+        }
+
+        $isPrimary = $locale === $primaryLocale;
+        $handle = (!$isPrimary && $translatedHandle !== null && $translatedHandle !== '')
+            ? $translatedHandle
+            : $defaultHandle;
+
+        if ($handle === '') {
+            return $baseUrl;
+        }
+
+        $url = $parsed['scheme'] . '://' . $parsed['host'];
+        if (isset($parsed['port'])) {
+            $url .= ':' . $parsed['port'];
+        }
+        if (!$isPrimary) {
+            $url .= '/' . $locale;
+        }
+        $url .= '/products/' . $handle;
+        if (isset($parsed['query']) && $parsed['query'] !== '') {
+            $url .= '?' . $parsed['query'];
+        }
+
+        return $url;
     }
 
     /**

--- a/src/Adapters/ShopifyAdapter.php
+++ b/src/Adapters/ShopifyAdapter.php
@@ -485,6 +485,9 @@ class ShopifyAdapter
         if (isset($parsed['query']) && $parsed['query'] !== '') {
             $url .= '?' . $parsed['query'];
         }
+        if (isset($parsed['fragment']) && $parsed['fragment'] !== '') {
+            $url .= '#' . $parsed['fragment'];
+        }
 
         return $url;
     }

--- a/tests/Adapters/ShopifyAdapterTest.php
+++ b/tests/Adapters/ShopifyAdapterTest.php
@@ -696,6 +696,21 @@ class ShopifyAdapterTest extends TestCase
         $this->assertEquals('https://shop.example.com/lt/products/snieglente', $p['productUrl_lt']);
     }
 
+    public function testProductUrlFallsBackToUrlParsedHandleWhenHandleFieldMissing(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+        // no $product['node']['handle'] — simulates payloads from older shopify-app versions
+        $product['node']['onlineStoreUrl'] = 'https://shop.example.com/products/my-board';
+
+        $data = $this->makeShopifyResponse([$product], 'en');
+
+        $result = $this->adapter->transform($data, ['en', 'lt']);
+
+        $p = $result['products'][0];
+        $this->assertEquals('https://shop.example.com/products/my-board', $p['productUrl_en']);
+        $this->assertEquals('https://shop.example.com/lt/products/my-board', $p['productUrl_lt']);
+    }
+
     public function testProductUrlPreservesPreviewQueryStringForDevStores(): void
     {
         $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');

--- a/tests/Adapters/ShopifyAdapterTest.php
+++ b/tests/Adapters/ShopifyAdapterTest.php
@@ -660,9 +660,10 @@ class ShopifyAdapterTest extends TestCase
         $this->assertEquals('https://shop.example.com/products/snowboard', $result['products'][0]['productUrl']);
     }
 
-    public function testProductUrlDuplicatedAcrossLocales(): void
+    public function testProductUrlPrependsLocalePrefixForNonPrimary(): void
     {
         $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+        $product['node']['handle'] = 'snowboard';
         $product['node']['onlineStoreUrl'] = 'https://shop.example.com/products/snowboard';
 
         $data = $this->makeShopifyResponse([$product], 'en');
@@ -671,7 +672,44 @@ class ShopifyAdapterTest extends TestCase
 
         $p = $result['products'][0];
         $this->assertEquals('https://shop.example.com/products/snowboard', $p['productUrl_en']);
-        $this->assertEquals('https://shop.example.com/products/snowboard', $p['productUrl_lt']);
+        $this->assertEquals('https://shop.example.com/lt/products/snowboard', $p['productUrl_lt']);
+    }
+
+    public function testProductUrlUsesTranslatedHandleWhenPresent(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+        $product['node']['handle'] = 'snowboard';
+        $product['node']['onlineStoreUrl'] = 'https://shop.example.com/products/snowboard';
+        $product['node']['translations'] = [
+            'lt' => [
+                ['key' => 'handle', 'value' => 'snieglente'],
+                ['key' => 'title', 'value' => 'Snieglentė'],
+            ],
+        ];
+
+        $data = $this->makeShopifyResponse([$product], 'en');
+
+        $result = $this->adapter->transform($data, ['en', 'lt']);
+
+        $p = $result['products'][0];
+        $this->assertEquals('https://shop.example.com/products/snowboard', $p['productUrl_en']);
+        $this->assertEquals('https://shop.example.com/lt/products/snieglente', $p['productUrl_lt']);
+    }
+
+    public function testProductUrlPreservesPreviewQueryStringForDevStores(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+        $product['node']['handle'] = 'snowboard';
+        $product['node']['onlineStoreUrl'] = null;
+        $product['node']['onlineStorePreviewUrl'] = 'https://shop.myshopify.com/products/snowboard?preview_key=abc123';
+
+        $data = $this->makeShopifyResponse([$product], 'en');
+
+        $result = $this->adapter->transform($data, ['en', 'lt']);
+
+        $p = $result['products'][0];
+        $this->assertEquals('https://shop.myshopify.com/products/snowboard?preview_key=abc123', $p['productUrl_en']);
+        $this->assertEquals('https://shop.myshopify.com/lt/products/snowboard?preview_key=abc123', $p['productUrl_lt']);
     }
 
     // ─── Error handling ───


### PR DESCRIPTION
Fixes localized product URLs in indexed Shopify documents. Per-locale productUrl_<locale> now uses the locale prefix (/lt/...) and the translated handle from the Shopify translations payload, instead of duplicating the default-locale URL across every locale. 

Build productUrl_<locale> with the active locale prefix and the
  translated handle when present, falling back to the default handle.                                                                                                                                                                                                           
  Preserves preview query strings for dev stores.  

<img width="841" height="690" alt="Screenshot 2026-05-07 at 12 03 16" src="https://github.com/user-attachments/assets/4c2d0068-94da-4fa3-b8dc-1044d336f8fe" />
