### PR TITLE
BRD-1043-Surface-variant-URL-and-price-in-Shopify-search-index

### DIFF
--- a/src/Adapters/ShopifyAdapter.php
+++ b/src/Adapters/ShopifyAdapter.php
@@ -133,7 +133,14 @@ class ShopifyAdapter
         }
 
         if (isset($product['variants']) && is_array($product['variants'])) {
-            $result['variants'] = $this->transformVariants($product['variants'], $locales);
+            $result['variants'] = $this->transformVariants(
+                $product['variants'],
+                $locales,
+                $productUrl,
+                $defaultHandle,
+                $translations,
+                $primaryLocale,
+            );
         }
 
         return $result;
@@ -455,6 +462,7 @@ class ShopifyAdapter
         ?string $translatedHandle,
         string $locale,
         string $primaryLocale,
+        array $extraQuery = [],
     ): string {
         if ($baseUrl === '') {
             return '';
@@ -482,8 +490,15 @@ class ShopifyAdapter
             $url .= '/' . $locale;
         }
         $url .= '/products/' . $handle;
+
+        $existingQuery = [];
         if (isset($parsed['query']) && $parsed['query'] !== '') {
-            $url .= '?' . $parsed['query'];
+            parse_str($parsed['query'], $existingQuery);
+        }
+        // Existing query (e.g. preview_key) wins on key collision.
+        $mergedQuery = $existingQuery + $extraQuery;
+        if (!empty($mergedQuery)) {
+            $url .= '?' . http_build_query($mergedQuery);
         }
         if (isset($parsed['fragment']) && $parsed['fragment'] !== '') {
             $url .= '#' . $parsed['fragment'];
@@ -655,14 +670,27 @@ class ShopifyAdapter
 
     /**
      * Transform Shopify variants to BradSearch format.
+     *
+     * Variant `imageUrl` is intentionally omitted: the parent product's curated
+     * `featuredImage` is the merchant-approved hero image, and we don't want
+     * variant enrichment to swap it for a per-variant photo at search time.
+     *
+     * @param array<string> $locales
+     * @param array<string, mixed> $translations
      */
-    private function transformVariants(array $variantsData, array $locales): array
-    {
+    private function transformVariants(
+        array $variantsData,
+        array $locales,
+        string $productUrl = '',
+        string $defaultHandle = '',
+        array $translations = [],
+        string $primaryLocale = '',
+    ): array {
         if (! isset($variantsData['edges']) || ! is_array($variantsData['edges'])) {
             return [];
         }
 
-        return array_map(function (array $edge) use ($locales): array {
+        return array_map(function (array $edge) use ($locales, $productUrl, $defaultHandle, $translations, $primaryLocale): array {
             if (! isset($edge['node']) || ! is_array($edge['node'])) {
                 throw new ValidationException('Variant has malformed node structure');
             }
@@ -673,15 +701,61 @@ class ShopifyAdapter
                 throw new ValidationException('Variant is missing required ID field');
             }
 
+            $variantId = $this->extractNumericId($variant['id']);
             $options = $variant['selectedOptions'] ?? [];
 
-            return [
-                'id' => $this->extractNumericId($variant['id']),
-                'sku' => $variant['sku'] ?? '',
-                ...! empty($locales)
-                    ? ['attrs' => $this->transformVariantOptionsWithLocales($options, $locales)]
-                    : ['attributes' => $this->transformVariantOptions($options)],
+            $price = isset($variant['price']) && is_scalar($variant['price']) ? (string) $variant['price'] : '';
+            $compareAt = isset($variant['compareAtPrice']) && is_scalar($variant['compareAtPrice'])
+                ? (string) $variant['compareAtPrice']
+                : '';
+            $basePrice = ($compareAt !== '' && bccomp($compareAt, '0.00', 2) > 0) ? $compareAt : $price;
+
+            $result = [
+                'id' => $variantId,
+                'sku' => is_string($variant['sku'] ?? null) ? $variant['sku'] : '',
             ];
+
+            if ($price !== '') {
+                $result['price'] = $price;
+                $result['priceTaxExcluded'] = $price;
+            }
+            if ($basePrice !== '') {
+                $result['basePrice'] = $basePrice;
+                $result['basePriceTaxExcluded'] = $basePrice;
+            }
+
+            if (! empty($locales)) {
+                $result['attrs'] = $this->transformVariantOptionsWithLocales($options, $locales);
+                foreach ($locales as $locale) {
+                    $localeTranslations = $this->resolveTranslationsForLocale($locale, $primaryLocale, $translations);
+                    $url = $this->buildLocaleProductUrl(
+                        $productUrl,
+                        $defaultHandle,
+                        $this->translated($localeTranslations, 'handle'),
+                        $locale,
+                        $primaryLocale,
+                        ['variant' => $variantId],
+                    );
+                    if ($url !== '') {
+                        $result["productUrl_{$locale}"] = $url;
+                    }
+                }
+            } else {
+                $result['attributes'] = $this->transformVariantOptions($options);
+                $url = $this->buildLocaleProductUrl(
+                    $productUrl,
+                    $defaultHandle,
+                    null,
+                    $primaryLocale,
+                    $primaryLocale,
+                    ['variant' => $variantId],
+                );
+                if ($url !== '') {
+                    $result['productUrl'] = $url;
+                }
+            }
+
+            return $result;
         }, $variantsData['edges']);
     }
 

--- a/src/Adapters/ShopifyAdapter.php
+++ b/src/Adapters/ShopifyAdapter.php
@@ -495,8 +495,10 @@ class ShopifyAdapter
         if (isset($parsed['query']) && $parsed['query'] !== '') {
             parse_str($parsed['query'], $existingQuery);
         }
-        // Existing query (e.g. preview_key) wins on key collision.
-        $mergedQuery = $existingQuery + $extraQuery;
+        // $extraQuery wins on key collision: when a base URL already pins a default
+        // variant (e.g. ?variant=111), our per-variant deep-link must override it.
+        // Non-conflicting keys like preview_key are preserved from $existingQuery.
+        $mergedQuery = array_merge($existingQuery, $extraQuery);
         if (!empty($mergedQuery)) {
             $url .= '?' . http_build_query($mergedQuery);
         }
@@ -690,7 +692,15 @@ class ShopifyAdapter
             return [];
         }
 
-        return array_map(function (array $edge) use ($locales, $productUrl, $defaultHandle, $translations, $primaryLocale): array {
+        // Translated handles are product-level, so resolve once per locale rather
+        // than re-running the lookup for every variant × locale pair.
+        $localeHandles = [];
+        foreach ($locales as $locale) {
+            $localeTranslations = $this->resolveTranslationsForLocale($locale, $primaryLocale, $translations);
+            $localeHandles[$locale] = $this->translated($localeTranslations, 'handle');
+        }
+
+        return array_map(function (array $edge) use ($locales, $productUrl, $defaultHandle, $primaryLocale, $localeHandles): array {
             if (! isset($edge['node']) || ! is_array($edge['node'])) {
                 throw new ValidationException('Variant has malformed node structure');
             }
@@ -704,8 +714,8 @@ class ShopifyAdapter
             $variantId = $this->extractNumericId($variant['id']);
             $options = $variant['selectedOptions'] ?? [];
 
-            $price = isset($variant['price']) && is_scalar($variant['price']) ? (string) $variant['price'] : '';
-            $compareAt = isset($variant['compareAtPrice']) && is_scalar($variant['compareAtPrice'])
+            $price = isset($variant['price']) && is_numeric($variant['price']) ? (string) $variant['price'] : '';
+            $compareAt = isset($variant['compareAtPrice']) && is_numeric($variant['compareAtPrice'])
                 ? (string) $variant['compareAtPrice']
                 : '';
             $basePrice = ($compareAt !== '' && bccomp($compareAt, '0.00', 2) > 0) ? $compareAt : $price;
@@ -727,11 +737,10 @@ class ShopifyAdapter
             if (! empty($locales)) {
                 $result['attrs'] = $this->transformVariantOptionsWithLocales($options, $locales);
                 foreach ($locales as $locale) {
-                    $localeTranslations = $this->resolveTranslationsForLocale($locale, $primaryLocale, $translations);
                     $url = $this->buildLocaleProductUrl(
                         $productUrl,
                         $defaultHandle,
-                        $this->translated($localeTranslations, 'handle'),
+                        $localeHandles[$locale] ?? null,
                         $locale,
                         $primaryLocale,
                         ['variant' => $variantId],

--- a/tests/Adapters/ShopifyAdapterTest.php
+++ b/tests/Adapters/ShopifyAdapterTest.php
@@ -596,6 +596,65 @@ class ShopifyAdapterTest extends TestCase
         $this->assertEquals('99.95', $variant['basePriceTaxExcluded']);
     }
 
+    public function testVariantUrlOverridesDefaultVariantParamFromBaseUrl(): void
+    {
+        // If onlineStoreUrl already pins ?variant=111 (some themes do this for the
+        // canonical variant), the per-variant deep-link must still win — otherwise
+        // every indexed variant would point to the same default variant.
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+        $product['node']['handle'] = 'snowboard';
+        $product['node']['onlineStoreUrl'] = 'https://shop.example.com/products/snowboard?variant=111';
+        $product['node']['variants'] = [
+            'edges' => [
+                [
+                    'node' => [
+                        'id' => 'gid://shopify/ProductVariant/12345',
+                        'sku' => 'SNO-001',
+                        'price' => '79.95',
+                        'selectedOptions' => [],
+                    ],
+                ],
+            ],
+        ];
+
+        $data = $this->makeShopifyResponse([$product]);
+
+        $result = $this->adapter->transform($data, []);
+
+        $variant = $result['products'][0]['variants'][0];
+        $this->assertEquals('https://shop.example.com/products/snowboard?variant=12345', $variant['productUrl']);
+    }
+
+    public function testVariantBasePriceFallsBackToPriceWhenCompareAtIsZero(): void
+    {
+        // Shopify reports "0.00" when no compare-at is configured; bccomp guard
+        // ensures basePrice still reflects the actual price rather than zero.
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+        $product['node']['handle'] = 'snowboard';
+        $product['node']['onlineStoreUrl'] = 'https://shop.example.com/products/snowboard';
+        $product['node']['variants'] = [
+            'edges' => [
+                [
+                    'node' => [
+                        'id' => 'gid://shopify/ProductVariant/12345',
+                        'sku' => 'SNO-001',
+                        'price' => '79.95',
+                        'compareAtPrice' => '0.00',
+                        'selectedOptions' => [],
+                    ],
+                ],
+            ],
+        ];
+
+        $data = $this->makeShopifyResponse([$product]);
+
+        $result = $this->adapter->transform($data, []);
+
+        $variant = $result['products'][0]['variants'][0];
+        $this->assertEquals('79.95', $variant['price']);
+        $this->assertEquals('79.95', $variant['basePrice']);
+    }
+
     public function testVariantBasePriceFallsBackToPriceWhenCompareAtMissing(): void
     {
         $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');

--- a/tests/Adapters/ShopifyAdapterTest.php
+++ b/tests/Adapters/ShopifyAdapterTest.php
@@ -480,6 +480,185 @@ class ShopifyAdapterTest extends TestCase
         $this->assertArrayHasKey('material-fabric', $attrs);
     }
 
+    // ─── Variant URL / price / image ───
+
+    public function testVariantsCarryLocalizedProductUrlWithVariantQueryParam(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+        $product['node']['handle'] = 'snowboard';
+        $product['node']['onlineStoreUrl'] = 'https://shop.example.com/products/snowboard';
+        $product['node']['translations'] = [
+            'lt' => [['key' => 'handle', 'value' => 'snieglente']],
+        ];
+        $product['node']['variants'] = [
+            'edges' => [
+                [
+                    'node' => [
+                        'id' => 'gid://shopify/ProductVariant/12345',
+                        'sku' => 'SNO-001',
+                        'price' => '99.95',
+                        'selectedOptions' => [['name' => 'Size', 'value' => 'L']],
+                    ],
+                ],
+            ],
+        ];
+
+        $data = $this->makeShopifyResponse([$product], 'en');
+
+        $result = $this->adapter->transform($data, ['en', 'lt']);
+
+        $variant = $result['products'][0]['variants'][0];
+        $this->assertEquals('https://shop.example.com/products/snowboard?variant=12345', $variant['productUrl_en']);
+        $this->assertEquals('https://shop.example.com/lt/products/snieglente?variant=12345', $variant['productUrl_lt']);
+    }
+
+    public function testVariantsCarryProductUrlWithoutLocales(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+        $product['node']['handle'] = 'snowboard';
+        $product['node']['onlineStoreUrl'] = 'https://shop.example.com/products/snowboard';
+        $product['node']['variants'] = [
+            'edges' => [
+                [
+                    'node' => [
+                        'id' => 'gid://shopify/ProductVariant/12345',
+                        'sku' => 'SNO-001',
+                        'price' => '99.95',
+                        'selectedOptions' => [['name' => 'Color', 'value' => 'White']],
+                    ],
+                ],
+            ],
+        ];
+
+        $data = $this->makeShopifyResponse([$product]);
+
+        $result = $this->adapter->transform($data, []);
+
+        $variant = $result['products'][0]['variants'][0];
+        $this->assertEquals('https://shop.example.com/products/snowboard?variant=12345', $variant['productUrl']);
+    }
+
+    public function testVariantUrlPreservesPreviewKeyAlongsideVariantParam(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+        $product['node']['handle'] = 'snowboard';
+        $product['node']['onlineStoreUrl'] = null;
+        $product['node']['onlineStorePreviewUrl'] = 'https://shop.myshopify.com/products/snowboard?preview_key=abc123';
+        $product['node']['variants'] = [
+            'edges' => [
+                [
+                    'node' => [
+                        'id' => 'gid://shopify/ProductVariant/12345',
+                        'sku' => 'SNO-001',
+                        'price' => '99.95',
+                        'selectedOptions' => [],
+                    ],
+                ],
+            ],
+        ];
+
+        $data = $this->makeShopifyResponse([$product], 'en');
+
+        $result = $this->adapter->transform($data, ['en', 'lt']);
+
+        $variant = $result['products'][0]['variants'][0];
+        $this->assertEquals('https://shop.myshopify.com/products/snowboard?preview_key=abc123&variant=12345', $variant['productUrl_en']);
+        $this->assertEquals('https://shop.myshopify.com/lt/products/snowboard?preview_key=abc123&variant=12345', $variant['productUrl_lt']);
+    }
+
+    public function testVariantsCarryPriceAndBasePriceFromCompareAtPrice(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+        $product['node']['handle'] = 'snowboard';
+        $product['node']['onlineStoreUrl'] = 'https://shop.example.com/products/snowboard';
+        $product['node']['variants'] = [
+            'edges' => [
+                [
+                    'node' => [
+                        'id' => 'gid://shopify/ProductVariant/12345',
+                        'sku' => 'SNO-001',
+                        'price' => '79.95',
+                        'compareAtPrice' => '99.95',
+                        'selectedOptions' => [],
+                    ],
+                ],
+            ],
+        ];
+
+        $data = $this->makeShopifyResponse([$product]);
+
+        $result = $this->adapter->transform($data, []);
+
+        $variant = $result['products'][0]['variants'][0];
+        $this->assertEquals('79.95', $variant['price']);
+        $this->assertEquals('79.95', $variant['priceTaxExcluded']);
+        $this->assertEquals('99.95', $variant['basePrice']);
+        $this->assertEquals('99.95', $variant['basePriceTaxExcluded']);
+    }
+
+    public function testVariantBasePriceFallsBackToPriceWhenCompareAtMissing(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+        $product['node']['handle'] = 'snowboard';
+        $product['node']['onlineStoreUrl'] = 'https://shop.example.com/products/snowboard';
+        $product['node']['variants'] = [
+            'edges' => [
+                [
+                    'node' => [
+                        'id' => 'gid://shopify/ProductVariant/12345',
+                        'sku' => 'SNO-001',
+                        'price' => '79.95',
+                        'compareAtPrice' => null,
+                        'selectedOptions' => [],
+                    ],
+                ],
+            ],
+        ];
+
+        $data = $this->makeShopifyResponse([$product]);
+
+        $result = $this->adapter->transform($data, []);
+
+        $variant = $result['products'][0]['variants'][0];
+        $this->assertEquals('79.95', $variant['price']);
+        $this->assertEquals('79.95', $variant['basePrice']);
+    }
+
+    public function testVariantsDoNotCarryImageUrl(): void
+    {
+        // Per merchant feedback: search rows must show the curated featuredImage,
+        // not whatever variant happens to match. Keeping imageUrl off the variant
+        // means variant enrichment can't swap the parent's hero image at search time.
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Snowboard', 'Desc', 'BrandX', 'Sports');
+        $product['node']['handle'] = 'snowboard';
+        $product['node']['onlineStoreUrl'] = 'https://shop.example.com/products/snowboard';
+        $product['node']['images'] = [
+            'edges' => [
+                ['node' => ['url' => 'https://cdn.shopify.com/product-image.jpg', 'width' => 800, 'height' => 800]],
+            ],
+        ];
+        $product['node']['variants'] = [
+            'edges' => [
+                [
+                    'node' => [
+                        'id' => 'gid://shopify/ProductVariant/12345',
+                        'sku' => 'SNO-001',
+                        'price' => '79.95',
+                        'selectedOptions' => [],
+                    ],
+                ],
+            ],
+        ];
+
+        $data = $this->makeShopifyResponse([$product]);
+
+        $result = $this->adapter->transform($data, []);
+
+        $variant = $result['products'][0]['variants'][0];
+        $this->assertArrayNotHasKey('imageUrl', $variant);
+        $this->assertEquals('https://cdn.shopify.com/product-image.jpg', $result['products'][0]['imageUrl']['small']);
+    }
+
     // ─── Taxonomy category ───
 
     public function testTaxonomyFullNameWinsOverProductType(): void


### PR DESCRIPTION
Per-variant productUrl_<locale> with ?variant=<id> deep-linking and the
  locale prefix, plus price/basePrice/priceTaxExcluded fields. Variant
  imageUrl is intentionally omitted so the parent's curated featuredImage
  stays the search-row hero.
  
  Indexes Shopify variants with their own locale-prefixed productUrl (using ?variant=<id>) and price fields, so a search like "gloves xl" can deep-link to the matching variant via brad-search's variant enrichment. Variant imageUrl is intentionally left off — merchants want the curated featuredImage to remain the row hero regardless of which variant matched. (Greengoing case featuredImage)
  
  [BRD-1043](https://invertus.atlassian.net/browse/BRD-1043)
  
  
  
<img width="924" height="478" alt="Screenshot 2026-05-07 at 14 30 21" src="https://github.com/user-attachments/assets/ddc30843-7132-4873-92cb-39d1b8111474" />


https://github.com/user-attachments/assets/639eb869-f473-4a86-9078-f79c94ace3c0



[BRD-1043]: https://invertus.atlassian.net/browse/BRD-1043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ