### PR TITLE
Migrate Magento V2 sync from price_range to calculated_price

### DIFF
--- a/src/Adapters/MagentoAdapterV2.php
+++ b/src/Adapters/MagentoAdapterV2.php
@@ -306,7 +306,7 @@ class MagentoAdapterV2
     }
 
     /**
-     * Extract pricing from Magento price_range structure.
+     * Extract pricing from Magento calculated_price structure.
      *
      * @param array<string, mixed> $product
      * @return ProductPricing
@@ -315,19 +315,24 @@ class MagentoAdapterV2
     {
         $price = (float) (AdapterUtils::getNestedValue(
             $product,
-            ['price_range', 'minimum_price', 'final_price', 'value']
+            ['calculated_price', 'minimum_price', 'final_price', 'value']
         ) ?? 0);
 
         $priceTaxExcluded = (float) (AdapterUtils::getNestedValue(
             $product,
-            ['price_range', 'minimum_price', 'final_price_excl_tax', 'value']
+            ['calculated_price', 'minimum_price', 'final_price_excl_tax', 'value']
+        ) ?? $price);
+
+        $basePrice = (float) (AdapterUtils::getNestedValue(
+            $product,
+            ['calculated_price', 'minimum_price', 'regular_price', 'value']
         ) ?? $price);
 
         return new ProductPricing(
             price: $price,
-            basePrice: $price,
+            basePrice: $basePrice,
             priceTaxExcluded: $priceTaxExcluded,
-            basePriceTaxExcluded: $priceTaxExcluded
+            basePriceTaxExcluded: $basePrice,
         );
     }
 

--- a/src/Magento/MagentoProductQuery.php
+++ b/src/Magento/MagentoProductQuery.php
@@ -71,8 +71,9 @@ final class MagentoProductQuery
                 has_unit
             }
             image_optimized
-            price_range {
+            calculated_price {
                 minimum_price {
+                    regular_price { value currency }
                     final_price { value currency }
                     final_price_excl_tax { value currency }
                 }
@@ -99,8 +100,9 @@ GRAPHQL;
             name
             full_url
             stock_status
-            price_range {
+            calculated_price {
                 minimum_price {
+                    regular_price { value currency }
                     final_price { value currency }
                     final_price_excl_tax { value currency }
                 }

--- a/tests/Adapters/MagentoAdapterV2Test.php
+++ b/tests/Adapters/MagentoAdapterV2Test.php
@@ -513,8 +513,9 @@ class MagentoAdapterV2Test extends TestCase
     public function testPriceFlattenedFromNestedStructure(): void
     {
         $product = $this->buildMinimalProduct([
-            'price_range' => [
+            'calculated_price' => [
                 'minimum_price' => [
+                    'regular_price' => ['value' => 29.99],
                     'final_price' => ['value' => 29.99],
                     'final_price_excl_tax' => ['value' => 24.79],
                 ],
@@ -527,7 +528,7 @@ class MagentoAdapterV2Test extends TestCase
         $this->assertSame(29.99, $serialized['price']);
         $this->assertSame(29.99, $serialized['basePrice']);
         $this->assertSame(24.79, $serialized['priceTaxExcluded']);
-        $this->assertSame(24.79, $serialized['basePriceTaxExcluded']);
+        $this->assertSame(29.99, $serialized['basePriceTaxExcluded']);
     }
 
     public function testPriceFallsBackToZeroWhenMissing(): void
@@ -543,7 +544,7 @@ class MagentoAdapterV2Test extends TestCase
     public function testPriceTaxExcludedFallsBackToPrice(): void
     {
         $product = $this->buildMinimalProduct([
-            'price_range' => [
+            'calculated_price' => [
                 'minimum_price' => [
                     'final_price' => ['value' => 15.50],
                     // no final_price_excl_tax
@@ -556,6 +557,47 @@ class MagentoAdapterV2Test extends TestCase
 
         $this->assertSame(15.50, $serialized['price']);
         $this->assertSame(15.50, $serialized['priceTaxExcluded']);
+    }
+
+    public function testBasePriceUsesRegularPriceWhenDiscounted(): void
+    {
+        $product = $this->buildMinimalProduct([
+            'calculated_price' => [
+                'minimum_price' => [
+                    'regular_price' => ['value' => 50.00],
+                    'final_price' => ['value' => 40.00],
+                    'final_price_excl_tax' => ['value' => 33.06],
+                ],
+            ],
+        ]);
+
+        $result = $this->adapter->transformProduct($product);
+        $serialized = $result->jsonSerialize();
+
+        $this->assertSame(40.00, $serialized['price']);
+        $this->assertSame(50.00, $serialized['basePrice']);
+        $this->assertSame(33.06, $serialized['priceTaxExcluded']);
+        $this->assertSame(50.00, $serialized['basePriceTaxExcluded']);
+    }
+
+    public function testBasePriceFallsBackToPriceWhenRegularPriceMissing(): void
+    {
+        $product = $this->buildMinimalProduct([
+            'calculated_price' => [
+                'minimum_price' => [
+                    'final_price' => ['value' => 12.34],
+                    'final_price_excl_tax' => ['value' => 10.20],
+                ],
+            ],
+        ]);
+
+        $result = $this->adapter->transformProduct($product);
+        $serialized = $result->jsonSerialize();
+
+        $this->assertSame(12.34, $serialized['price']);
+        $this->assertSame(12.34, $serialized['basePrice']);
+        $this->assertSame(10.20, $serialized['priceTaxExcluded']);
+        $this->assertSame(12.34, $serialized['basePriceTaxExcluded']);
     }
 
     // --- Image URL Tests ---
@@ -731,8 +773,9 @@ class MagentoAdapterV2Test extends TestCase
             'short_description' => ['html' => '<p>Drill bit</p>'],
             'image_optimized' => 'https://shop.example.com/drill.jpg',
             'is_in_stock' => true,
-            'price_range' => [
+            'calculated_price' => [
                 'minimum_price' => [
+                    'regular_price' => ['value' => 5.99],
                     'final_price' => ['value' => 5.99],
                     'final_price_excl_tax' => ['value' => 4.95],
                 ],


### PR DESCRIPTION
## Summary

- Switch the Magento V2 GraphQL query and `MagentoAdapterV2::extractPricing()` from `price_range` to the new `calculated_price` field
- Use `calculated_price.minimum_price.regular_price.value` to populate `ProductPricing::basePrice`, so discounted products now expose a real pre-discount price instead of `basePrice` duplicating `price`
- `basePriceTaxExcluded` mirrors `basePrice` (API does not expose `regular_price_excl_tax`); `priceTaxExcluded` still falls back to `price` when `final_price_excl_tax` is absent
- V1 adapter (`MagentoAdapter`) intentionally left on `price_range`

## Test plan

- [x] `vendor/bin/phpunit tests/Adapters/MagentoAdapterV2Test.php` — 50/50 pass, including two new tests covering the discounted-product case and the missing-`regular_price` fallback
- [x] `vendor/bin/phpunit` — full suite 1574/1574 pass
- [x] `vendor/bin/phpstan analyse --memory-limit=1G` — clean
- [ ] Manual sanity check against a staging Magento returning `calculated_price` for a known-discounted SKU: confirm `basePrice > price` in the Brad Search payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)