### PR TITLE
BRD-804-synonym-configuration

### DIFF
--- a/src/SyncV2Sdk.php
+++ b/src/SyncV2Sdk.php
@@ -207,6 +207,10 @@ class SyncV2Sdk
     /**
      * Get search synonyms for a specific language.
      *
+     * The returned response always carries a non-null synonyms array (empty
+     * when there are none), unlike SynonymResponse::fromArray() called directly
+     * without a synonyms key, which yields null.
+     *
      * @param  string  $language  Language code (e.g., "en", "lt")
      * @return SynonymResponse Typed response with synonyms data
      */

--- a/src/SyncV2Sdk.php
+++ b/src/SyncV2Sdk.php
@@ -216,15 +216,29 @@ class SyncV2Sdk
             $this->baseApiPath . 'synonyms?language=' . urlencode($language)
         );
 
-        // GET returns {language, synonyms} without count/reindex fields.
-        $synonyms = $response['synonyms'] ?? [];
+        return SynonymResponse::fromArray(
+            $this->withSynonymGetDefaults($response, $language)
+        );
+    }
 
-        return SynonymResponse::fromArray([
+    /**
+     * The GET endpoint may omit synonym_count/requires_reindex; default them so
+     * SynonymResponse::fromArray() always receives its required fields.
+     *
+     * @param  array<string, mixed>  $response
+     * @return array<string, mixed>
+     */
+    private function withSynonymGetDefaults(array $response, string $language): array
+    {
+        $synonyms = $response['synonyms'] ?? [];
+        $synonyms = is_array($synonyms) ? $synonyms : [];
+
+        return [
             'language' => $response['language'] ?? $language,
             'synonym_count' => $response['synonym_count'] ?? count($synonyms),
             'requires_reindex' => $response['requires_reindex'] ?? false,
             'synonyms' => $synonyms,
-        ]);
+        ];
     }
 
     /**

--- a/src/SyncV2Sdk.php
+++ b/src/SyncV2Sdk.php
@@ -216,7 +216,15 @@ class SyncV2Sdk
             $this->baseApiPath . 'synonyms?language=' . urlencode($language)
         );
 
-        return SynonymResponse::fromArray($response);
+        // GET returns {language, synonyms} without count/reindex fields.
+        $synonyms = $response['synonyms'] ?? [];
+
+        return SynonymResponse::fromArray([
+            'language' => $response['language'] ?? $language,
+            'synonym_count' => $response['synonym_count'] ?? count($synonyms),
+            'requires_reindex' => $response['requires_reindex'] ?? false,
+            'synonyms' => $synonyms,
+        ]);
     }
 
     /**

--- a/src/V2/ValueObjects/Index/IndexCreateRequest.php
+++ b/src/V2/ValueObjects/Index/IndexCreateRequest.php
@@ -6,6 +6,7 @@ namespace BradSearch\SyncSdk\V2\ValueObjects\Index;
 
 use BradSearch\SyncSdk\V2\Exceptions\InvalidArgumentException;
 use BradSearch\SyncSdk\V2\Exceptions\InvalidLocaleException;
+use BradSearch\SyncSdk\V2\ValueObjects\Synonym\SynonymConfiguration;
 use BradSearch\SyncSdk\V2\ValueObjects\ValueObject;
 
 /**
@@ -14,6 +15,9 @@ use BradSearch\SyncSdk\V2\ValueObjects\ValueObject;
  * This immutable ValueObject contains the required data for creating a new index:
  * - locales: Array of locale codes in 'xx-XX' format
  * - fields: Array of FieldDefinition objects
+ * - synonyms: Optional per-language synonym configurations, applied at index
+ *   creation so they take effect on activation without a separate post-activation
+ *   update (which would briefly close the active index).
  */
 final readonly class IndexCreateRequest extends ValueObject
 {
@@ -25,13 +29,16 @@ final readonly class IndexCreateRequest extends ValueObject
     /**
      * @param array<string> $locales Array of locale codes (e.g., ['lt-LT', 'en-US'])
      * @param array<FieldDefinition> $fields Array of field definitions
+     * @param array<SynonymConfiguration> $synonyms Optional per-language synonym configurations
      */
     public function __construct(
         array $locales,
-        public array $fields
+        public array $fields,
+        public array $synonyms = []
     ) {
         $this->validateLocales($locales);
         $this->validateFields($fields);
+        $this->validateSynonyms($synonyms);
         $this->locales = $locales;
     }
 
@@ -42,7 +49,7 @@ final readonly class IndexCreateRequest extends ValueObject
      */
     public function withLocales(array $locales): self
     {
-        return new self($locales, $this->fields);
+        return new self($locales, $this->fields, $this->synonyms);
     }
 
     /**
@@ -52,7 +59,17 @@ final readonly class IndexCreateRequest extends ValueObject
      */
     public function withFields(array $fields): self
     {
-        return new self($this->locales, $fields);
+        return new self($this->locales, $fields, $this->synonyms);
+    }
+
+    /**
+     * Returns a new instance with different synonym configurations.
+     *
+     * @param array<SynonymConfiguration> $synonyms
+     */
+    public function withSynonyms(array $synonyms): self
+    {
+        return new self($this->locales, $this->fields, $synonyms);
     }
 
     /**
@@ -60,7 +77,7 @@ final readonly class IndexCreateRequest extends ValueObject
      */
     public function withAddedLocale(string $locale): self
     {
-        return new self([...$this->locales, $locale], $this->fields);
+        return new self([...$this->locales, $locale], $this->fields, $this->synonyms);
     }
 
     /**
@@ -68,7 +85,15 @@ final readonly class IndexCreateRequest extends ValueObject
      */
     public function withAddedField(FieldDefinition $field): self
     {
-        return new self($this->locales, [...$this->fields, $field]);
+        return new self($this->locales, [...$this->fields, $field], $this->synonyms);
+    }
+
+    /**
+     * Returns a new instance with an additional synonym configuration.
+     */
+    public function withAddedSynonym(SynonymConfiguration $synonym): self
+    {
+        return new self($this->locales, $this->fields, [...$this->synonyms, $synonym]);
     }
 
     /**
@@ -76,13 +101,22 @@ final readonly class IndexCreateRequest extends ValueObject
      */
     public function jsonSerialize(): array
     {
-        return [
+        $data = [
             'locales' => $this->locales,
             'fields' => array_map(
                 fn(FieldDefinition $field) => $field->jsonSerialize(),
                 $this->fields
             ),
         ];
+
+        if ($this->synonyms !== []) {
+            $data['synonyms'] = array_map(
+                fn(SynonymConfiguration $synonym) => $synonym->jsonSerialize(),
+                $this->synonyms
+            );
+        }
+
+        return $data;
     }
 
     /**
@@ -139,6 +173,28 @@ final readonly class IndexCreateRequest extends ValueObject
                     sprintf('Field at index %d must be an instance of FieldDefinition.', $index),
                     'fields',
                     $field
+                );
+            }
+        }
+    }
+
+    /**
+     * Validates that all synonym entries are SynonymConfiguration instances.
+     *
+     * @param array<mixed> $synonyms
+     * @throws InvalidArgumentException If an entry is not a SynonymConfiguration
+     */
+    private function validateSynonyms(array $synonyms): void
+    {
+        foreach ($synonyms as $index => $synonym) {
+            if (!$synonym instanceof SynonymConfiguration) {
+                throw new InvalidArgumentException(
+                    sprintf(
+                        'Synonym at index %d must be an instance of SynonymConfiguration.',
+                        $index
+                    ),
+                    'synonyms',
+                    $synonym
                 );
             }
         }

--- a/src/V2/ValueObjects/Index/IndexCreateRequest.php
+++ b/src/V2/ValueObjects/Index/IndexCreateRequest.php
@@ -179,13 +179,17 @@ final readonly class IndexCreateRequest extends ValueObject
     }
 
     /**
-     * Validates that all synonym entries are SynonymConfiguration instances.
+     * Validates that all synonym entries are SynonymConfiguration instances and
+     * that each language appears at most once.
      *
      * @param array<mixed> $synonyms
      * @throws InvalidArgumentException If an entry is not a SynonymConfiguration
+     *                                  or a language is configured more than once
      */
     private function validateSynonyms(array $synonyms): void
     {
+        $seenLanguages = [];
+
         foreach ($synonyms as $index => $synonym) {
             if (!$synonym instanceof SynonymConfiguration) {
                 throw new InvalidArgumentException(
@@ -197,6 +201,20 @@ final readonly class IndexCreateRequest extends ValueObject
                     $synonym
                 );
             }
+
+            if (isset($seenLanguages[$synonym->language])) {
+                throw new InvalidArgumentException(
+                    sprintf(
+                        'Duplicate synonym configuration for language "%s" at index %d; each language must appear at most once.',
+                        $synonym->language,
+                        $index
+                    ),
+                    'synonyms',
+                    $synonyms
+                );
+            }
+
+            $seenLanguages[$synonym->language] = true;
         }
     }
 }

--- a/src/V2/ValueObjects/Response/SynonymResponse.php
+++ b/src/V2/ValueObjects/Response/SynonymResponse.php
@@ -68,16 +68,24 @@ final readonly class SynonymResponse extends ValueObject
      * The API returns each synonym group as a Solr-format string
      * ("laptop, notebook"); normalize those into term arrays.
      *
-     * @param array<int, mixed>|null $synonyms
+     * Non-array payloads (null, or the whole field arriving as a single
+     * string) yield null rather than a TypeError, since fromArray() is public.
+     * Malformed entries that normalize to an empty group are dropped so the
+     * result never carries an untraceable [].
+     *
+     * @param mixed $synonyms
      * @return array<int, array<int, string>>|null
      */
-    private static function normalizeSynonyms(?array $synonyms): ?array
+    private static function normalizeSynonyms(mixed $synonyms): ?array
     {
-        if ($synonyms === null) {
+        if (!is_array($synonyms)) {
             return null;
         }
 
-        return array_map(self::normalizeGroup(...), $synonyms);
+        return array_values(array_filter(
+            array_map(self::normalizeGroup(...), $synonyms),
+            static fn(array $group): bool => !empty($group)
+        ));
     }
 
     /**

--- a/src/V2/ValueObjects/Response/SynonymResponse.php
+++ b/src/V2/ValueObjects/Response/SynonymResponse.php
@@ -57,7 +57,28 @@ final readonly class SynonymResponse extends ValueObject
             language: (string) $data['language'],
             synonymCount: (int) $data['synonym_count'],
             requiresReindex: (bool) $data['requires_reindex'],
-            synonyms: $data['synonyms'] ?? null
+            synonyms: self::normalizeSynonyms($data['synonyms'] ?? null)
+        );
+    }
+
+    /**
+     * The API returns each synonym group as a Solr-format string
+     * ("laptop, notebook"); normalize those into term arrays.
+     *
+     * @param array<int, string|array<int, string>>|null $synonyms
+     * @return array<int, array<int, string>>|null
+     */
+    private static function normalizeSynonyms(?array $synonyms): ?array
+    {
+        if ($synonyms === null) {
+            return null;
+        }
+
+        return array_map(
+            static fn(string|array $group): array => is_string($group)
+                ? array_map('trim', explode(',', $group))
+                : $group,
+            $synonyms
         );
     }
 

--- a/src/V2/ValueObjects/Response/SynonymResponse.php
+++ b/src/V2/ValueObjects/Response/SynonymResponse.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BradSearch\SyncSdk\V2\ValueObjects\Response;
 
 use BradSearch\SyncSdk\V2\Exceptions\InvalidArgumentException;
+use BradSearch\SyncSdk\V2\ValueObjects\Synonym\NormalizesSynonymGroups;
 use BradSearch\SyncSdk\V2\ValueObjects\ValueObject;
 
 /**
@@ -18,6 +19,8 @@ use BradSearch\SyncSdk\V2\ValueObjects\ValueObject;
  */
 final readonly class SynonymResponse extends ValueObject
 {
+    use NormalizesSynonymGroups;
+
     private const LANGUAGE_PATTERN = '/^[a-z]{2}$/';
 
     /**
@@ -65,7 +68,7 @@ final readonly class SynonymResponse extends ValueObject
      * The API returns each synonym group as a Solr-format string
      * ("laptop, notebook"); normalize those into term arrays.
      *
-     * @param array<int, string|array<int, string>>|null $synonyms
+     * @param array<int, mixed>|null $synonyms
      * @return array<int, array<int, string>>|null
      */
     private static function normalizeSynonyms(?array $synonyms): ?array
@@ -74,12 +77,7 @@ final readonly class SynonymResponse extends ValueObject
             return null;
         }
 
-        return array_map(
-            static fn(string|array $group): array => is_string($group)
-                ? array_map('trim', explode(',', $group))
-                : $group,
-            $synonyms
-        );
+        return array_map(self::normalizeGroup(...), $synonyms);
     }
 
     /**

--- a/src/V2/ValueObjects/Synonym/NormalizesSynonymGroups.php
+++ b/src/V2/ValueObjects/Synonym/NormalizesSynonymGroups.php
@@ -22,15 +22,29 @@ trait NormalizesSynonymGroups
     private static function normalizeGroup(mixed $group): array
     {
         if (is_string($group)) {
-            return array_map('trim', explode(',', $group));
+            return self::trimTerms(explode(',', $group));
         }
 
         if (!is_array($group)) {
             return [];
         }
 
+        return self::trimTerms(array_map(
+            static fn(mixed $term): string => is_string($term) ? $term : '',
+            $group
+        ));
+    }
+
+    /**
+     * Trims terms and discards any that are empty after trimming.
+     *
+     * @param array<int, string> $terms
+     * @return array<int, string>
+     */
+    private static function trimTerms(array $terms): array
+    {
         return array_values(array_filter(
-            array_map(static fn(mixed $term): string => is_string($term) ? trim($term) : '', $group),
+            array_map('trim', $terms),
             static fn(string $term): bool => $term !== ''
         ));
     }

--- a/src/V2/ValueObjects/Synonym/NormalizesSynonymGroups.php
+++ b/src/V2/ValueObjects/Synonym/NormalizesSynonymGroups.php
@@ -13,8 +13,9 @@ namespace BradSearch\SyncSdk\V2\ValueObjects\Synonym;
 trait NormalizesSynonymGroups
 {
     /**
-     * Normalizes a single synonym group: Solr-format strings are split on
-     * commas, arrays pass through, anything else collapses to an empty group.
+     * Normalizes a single synonym group into trimmed string terms: Solr-format
+     * strings are split on commas; arrays have their string elements trimmed and
+     * non-string elements discarded; anything else collapses to an empty group.
      *
      * @return array<int, string>
      */
@@ -24,6 +25,13 @@ trait NormalizesSynonymGroups
             return array_map('trim', explode(',', $group));
         }
 
-        return is_array($group) ? array_values($group) : [];
+        if (!is_array($group)) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            array_map(static fn(mixed $term): string => is_string($term) ? trim($term) : '', $group),
+            static fn(string $term): bool => $term !== ''
+        ));
     }
 }

--- a/src/V2/ValueObjects/Synonym/NormalizesSynonymGroups.php
+++ b/src/V2/ValueObjects/Synonym/NormalizesSynonymGroups.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BradSearch\SyncSdk\V2\ValueObjects\Synonym;
+
+/**
+ * Normalizes synonym groups from API payloads into term arrays.
+ *
+ * The API returns each group as a Solr-format equivalence string
+ * ("laptop, notebook"); this trait converts those into term arrays.
+ */
+trait NormalizesSynonymGroups
+{
+    /**
+     * Normalizes a single synonym group: Solr-format strings are split on
+     * commas, arrays pass through, anything else collapses to an empty group.
+     *
+     * @return array<int, string>
+     */
+    private static function normalizeGroup(mixed $group): array
+    {
+        if (is_string($group)) {
+            return array_map('trim', explode(',', $group));
+        }
+
+        return is_array($group) ? array_values($group) : [];
+    }
+}

--- a/src/V2/ValueObjects/Synonym/SynonymConfiguration.php
+++ b/src/V2/ValueObjects/Synonym/SynonymConfiguration.php
@@ -58,13 +58,35 @@ final readonly class SynonymConfiguration extends ValueObject
     }
 
     /**
+     * Creates a SynonymConfiguration from an API response payload, where each
+     * synonym group is a Solr-format string (e.g. "laptop, notebook").
+     *
+     * @param array<string, mixed> $data
+     */
+    public static function fromApiResponse(array $data): self
+    {
+        $synonyms = array_map(
+            static fn(string $group): array => array_map('trim', explode(',', $group)),
+            $data['synonyms'] ?? []
+        );
+
+        return new self((string) ($data['language'] ?? ''), $synonyms);
+    }
+
+    /**
+     * The API expects each synonym group as a Solr-format equivalence string
+     * ("laptop, notebook, computer"), not as a nested array.
+     *
      * @return array<string, mixed>
      */
     public function jsonSerialize(): array
     {
         return [
             'language' => $this->language,
-            'synonyms' => $this->synonyms,
+            'synonyms' => array_map(
+                static fn(array $group): string => implode(', ', $group),
+                $this->synonyms
+            ),
         ];
     }
 
@@ -145,6 +167,19 @@ final readonly class SynonymConfiguration extends ValueObject
                             'Synonym term at index [%d][%d] cannot be empty.',
                             $index,
                             $termIndex
+                        ),
+                        'synonyms',
+                        $synonyms
+                    );
+                }
+
+                if (str_contains($term, ',') || str_contains($term, '=>')) {
+                    throw new InvalidArgumentException(
+                        sprintf(
+                            'Synonym term at index [%d][%d] must not contain "," or "=>" (Solr syntax characters), got "%s".',
+                            $index,
+                            $termIndex,
+                            $term
                         ),
                         'synonyms',
                         $synonyms

--- a/src/V2/ValueObjects/Synonym/SynonymConfiguration.php
+++ b/src/V2/ValueObjects/Synonym/SynonymConfiguration.php
@@ -15,6 +15,8 @@ use BradSearch\SyncSdk\V2\ValueObjects\ValueObject;
  */
 final readonly class SynonymConfiguration extends ValueObject
 {
+    use NormalizesSynonymGroups;
+
     private const LANGUAGE_PATTERN = '/^[a-z]{2}$/';
 
     /**
@@ -61,14 +63,22 @@ final readonly class SynonymConfiguration extends ValueObject
      * Creates a SynonymConfiguration from an API response payload, where each
      * synonym group is a Solr-format string (e.g. "laptop, notebook").
      *
+     * Returns null when the response carries no synonyms — an empty list is a
+     * valid API state, whereas constructing a config to send requires at least
+     * one group.
+     *
      * @param array<string, mixed> $data
      */
-    public static function fromApiResponse(array $data): self
+    public static function fromApiResponse(array $data): ?self
     {
-        $synonyms = array_map(
-            static fn(string $group): array => array_map('trim', explode(',', $group)),
-            $data['synonyms'] ?? []
-        );
+        $rawSynonyms = $data['synonyms'] ?? [];
+        $rawSynonyms = is_array($rawSynonyms) ? $rawSynonyms : [];
+
+        if (empty($rawSynonyms)) {
+            return null;
+        }
+
+        $synonyms = array_map(self::normalizeGroup(...), $rawSynonyms);
 
         return new self((string) ($data['language'] ?? ''), $synonyms);
     }
@@ -127,65 +137,90 @@ final readonly class SynonymConfiguration extends ValueObject
         }
 
         foreach ($synonyms as $index => $synonymGroup) {
-            if (!is_array($synonymGroup)) {
-                throw new InvalidArgumentException(
-                    sprintf(
-                        'Synonym group at index %d must be an array, got %s.',
-                        $index,
-                        gettype($synonymGroup)
-                    ),
-                    'synonyms',
-                    $synonyms
-                );
-            }
+            $this->validateSynonymGroup($index, $synonymGroup, $synonyms);
+        }
+    }
 
-            if (empty($synonymGroup)) {
-                throw new InvalidArgumentException(
-                    sprintf('Synonym group at index %d cannot be empty.', $index),
-                    'synonyms',
-                    $synonyms
-                );
-            }
+    /**
+     * Validates a single synonym group: it must be a non-empty array of terms.
+     *
+     * @param array<int, array<int, string>> $synonyms Full set, for error context
+     *
+     * @throws InvalidArgumentException If the group is not a non-empty array
+     */
+    private function validateSynonymGroup(int $index, mixed $synonymGroup, array $synonyms): void
+    {
+        if (!is_array($synonymGroup)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Synonym group at index %d must be an array, got %s.',
+                    $index,
+                    gettype($synonymGroup)
+                ),
+                'synonyms',
+                $synonyms
+            );
+        }
 
-            foreach ($synonymGroup as $termIndex => $term) {
-                if (!is_string($term)) {
-                    throw new InvalidArgumentException(
-                        sprintf(
-                            'Synonym term at index [%d][%d] must be a string, got %s.',
-                            $index,
-                            $termIndex,
-                            gettype($term)
-                        ),
-                        'synonyms',
-                        $synonyms
-                    );
-                }
+        if (empty($synonymGroup)) {
+            throw new InvalidArgumentException(
+                sprintf('Synonym group at index %d cannot be empty.', $index),
+                'synonyms',
+                $synonyms
+            );
+        }
 
-                if (trim($term) === '') {
-                    throw new InvalidArgumentException(
-                        sprintf(
-                            'Synonym term at index [%d][%d] cannot be empty.',
-                            $index,
-                            $termIndex
-                        ),
-                        'synonyms',
-                        $synonyms
-                    );
-                }
+        foreach ($synonymGroup as $termIndex => $term) {
+            $this->validateSynonymTerm($index, $termIndex, $term, $synonyms);
+        }
+    }
 
-                if (str_contains($term, ',') || str_contains($term, '=>')) {
-                    throw new InvalidArgumentException(
-                        sprintf(
-                            'Synonym term at index [%d][%d] must not contain "," or "=>" (Solr syntax characters), got "%s".',
-                            $index,
-                            $termIndex,
-                            $term
-                        ),
-                        'synonyms',
-                        $synonyms
-                    );
-                }
-            }
+    /**
+     * Validates a single synonym term: a non-empty string free of Solr syntax
+     * characters ("," and "=>").
+     *
+     * @param array<int, array<int, string>> $synonyms Full set, for error context
+     *
+     * @throws InvalidArgumentException If the term is invalid
+     */
+    private function validateSynonymTerm(int $index, int $termIndex, mixed $term, array $synonyms): void
+    {
+        if (!is_string($term)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Synonym term at index [%d][%d] must be a string, got %s.',
+                    $index,
+                    $termIndex,
+                    gettype($term)
+                ),
+                'synonyms',
+                $synonyms
+            );
+        }
+
+        if (trim($term) === '') {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Synonym term at index [%d][%d] cannot be empty.',
+                    $index,
+                    $termIndex
+                ),
+                'synonyms',
+                $synonyms
+            );
+        }
+
+        if (str_contains($term, ',') || str_contains($term, '=>')) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Synonym term at index [%d][%d] must not contain "," or "=>" (Solr syntax characters), got "%s".',
+                    $index,
+                    $termIndex,
+                    $term
+                ),
+                'synonyms',
+                $synonyms
+            );
         }
     }
 }

--- a/src/V2/ValueObjects/Synonym/SynonymConfiguration.php
+++ b/src/V2/ValueObjects/Synonym/SynonymConfiguration.php
@@ -68,6 +68,12 @@ final readonly class SynonymConfiguration extends ValueObject
      * one group.
      *
      * @param array<string, mixed> $data
+     *
+     * @throws InvalidArgumentException If a synonym group cannot be parsed
+     *                                  (e.g. a non-string/non-array entry that
+     *                                  normalizes to an empty group), unlike
+     *                                  SynonymResponse::normalizeSynonyms()
+     *                                  which drops such groups silently.
      */
     public static function fromApiResponse(array $data): ?self
     {

--- a/tests/SyncV2SdkTest.php
+++ b/tests/SyncV2SdkTest.php
@@ -967,13 +967,12 @@ class SyncV2SdkTest extends TestCase
     {
         $language = 'en';
 
+        // GET returns the SynonymConfiguration shape: Solr strings, no count/reindex fields
         $apiResponse = [
             'language' => 'en',
-            'synonym_count' => 2,
-            'requires_reindex' => false,
             'synonyms' => [
-                ['happy', 'joyful', 'cheerful'],
-                ['sad', 'unhappy', 'sorrowful'],
+                'happy, joyful, cheerful',
+                'sad, unhappy, sorrowful',
             ],
         ];
 
@@ -991,7 +990,31 @@ class SyncV2SdkTest extends TestCase
         $this->assertEquals('en', $result->language);
         $this->assertEquals(2, $result->synonymCount);
         $this->assertFalse($result->requiresReindex);
-        $this->assertCount(2, $result->synonyms);
+        $this->assertEquals(
+            [
+                ['happy', 'joyful', 'cheerful'],
+                ['sad', 'unhappy', 'sorrowful'],
+            ],
+            $result->synonyms
+        );
+    }
+
+    public function testGetSynonymsHandlesEmptyResult(): void
+    {
+        $httpClientMock = $this->createMock(HttpClient::class);
+        $httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn([
+                'language' => 'en',
+                'synonyms' => null,
+            ]);
+
+        $sdk = $this->createSdkWithMockedHttpClient($httpClientMock);
+        $result = $sdk->getSynonyms('en');
+
+        $this->assertEquals(0, $result->synonymCount);
+        $this->assertEquals([], $result->synonyms);
     }
 
     public function testGetSynonymsAppIdIncludedInUrlPath(): void

--- a/tests/V2/ValueObjects/Index/IndexCreateRequestTest.php
+++ b/tests/V2/ValueObjects/Index/IndexCreateRequestTest.php
@@ -511,6 +511,25 @@ class IndexCreateRequestTest extends TestCase
         $this->assertEquals($synonyms, $updated->synonyms);
     }
 
+    public function testWithAddedSynonymReturnsNewInstance(): void
+    {
+        $originalSynonym = new SynonymConfiguration('en', [['laptop', 'notebook']]);
+        $newSynonym = new SynonymConfiguration('lt', [['telefonas', 'mobilusis']]);
+
+        $request = new IndexCreateRequest(
+            ['en-US', 'lt-LT'],
+            [new FieldDefinition('name', FieldType::TEXT)],
+            [$originalSynonym]
+        );
+        $updated = $request->withAddedSynonym($newSynonym);
+
+        $this->assertNotSame($request, $updated);
+        $this->assertCount(1, $request->synonyms);
+        $this->assertCount(2, $updated->synonyms);
+        $this->assertSame($originalSynonym, $updated->synonyms[0]);
+        $this->assertSame($newSynonym, $updated->synonyms[1]);
+    }
+
     public function testThrowsExceptionForInvalidSynonymEntry(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -520,6 +539,52 @@ class IndexCreateRequestTest extends TestCase
             ['en-US'],
             [new FieldDefinition('name', FieldType::TEXT)],
             [['language' => 'en', 'synonyms' => [['laptop', 'notebook']]]]
+        );
+    }
+
+    /**
+     * @dataProvider builderProvider
+     * @param callable(IndexCreateRequest): IndexCreateRequest $builder
+     */
+    public function testBuildersPreserveSynonyms(callable $builder): void
+    {
+        $synonyms = [new SynonymConfiguration('en', [['laptop', 'notebook']])];
+        $request = new IndexCreateRequest(
+            ['en-US'],
+            [new FieldDefinition('name', FieldType::TEXT)],
+            $synonyms
+        );
+
+        $result = $builder($request);
+
+        $this->assertEquals($synonyms, $result->synonyms);
+    }
+
+    /**
+     * @return array<string, array{callable(IndexCreateRequest): IndexCreateRequest}>
+     */
+    public static function builderProvider(): array
+    {
+        return [
+            'withLocales' => [fn(IndexCreateRequest $r) => $r->withLocales(['lt-LT'])],
+            'withFields' => [fn(IndexCreateRequest $r) => $r->withFields([new FieldDefinition('title', FieldType::TEXT)])],
+            'withAddedLocale' => [fn(IndexCreateRequest $r) => $r->withAddedLocale('lt-LT')],
+            'withAddedField' => [fn(IndexCreateRequest $r) => $r->withAddedField(new FieldDefinition('title', FieldType::TEXT))],
+        ];
+    }
+
+    public function testThrowsExceptionForDuplicateSynonymLanguage(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Duplicate synonym configuration for language "en" at index 1');
+
+        new IndexCreateRequest(
+            ['en-US'],
+            [new FieldDefinition('name', FieldType::TEXT)],
+            [
+                new SynonymConfiguration('en', [['laptop', 'notebook']]),
+                new SynonymConfiguration('en', [['phone', 'mobile']]),
+            ]
         );
     }
 }

--- a/tests/V2/ValueObjects/Index/IndexCreateRequestTest.php
+++ b/tests/V2/ValueObjects/Index/IndexCreateRequestTest.php
@@ -10,6 +10,7 @@ use BradSearch\SyncSdk\V2\ValueObjects\Index\FieldDefinition;
 use BradSearch\SyncSdk\V2\ValueObjects\Index\FieldType;
 use BradSearch\SyncSdk\V2\ValueObjects\Index\IndexCreateRequest;
 use BradSearch\SyncSdk\V2\ValueObjects\Index\VariantAttribute;
+use BradSearch\SyncSdk\V2\ValueObjects\Synonym\SynonymConfiguration;
 use BradSearch\SyncSdk\V2\ValueObjects\ValueObject;
 use JsonSerializable;
 use PHPUnit\Framework\TestCase;
@@ -461,6 +462,64 @@ class IndexCreateRequestTest extends TestCase
                 ['name' => 'invalid', 'type' => 'text'],
                 new FieldDefinition('price', FieldType::DOUBLE),
             ]
+        );
+    }
+
+    public function testSynonymsDefaultToEmptyAndAreOmittedFromSerialization(): void
+    {
+        $request = new IndexCreateRequest(
+            ['lt-LT'],
+            [new FieldDefinition('id', FieldType::KEYWORD)]
+        );
+
+        $this->assertEquals([], $request->synonyms);
+        $this->assertArrayNotHasKey('synonyms', $request->jsonSerialize());
+    }
+
+    public function testSynonymsAreSerializedAsSolrStringsWhenProvided(): void
+    {
+        $request = new IndexCreateRequest(
+            ['en-US', 'lt-LT'],
+            [new FieldDefinition('name', FieldType::TEXT)],
+            [
+                new SynonymConfiguration('en', [['laptop', 'notebook']]),
+                new SynonymConfiguration('lt', [['telefonas', 'mobilusis']]),
+            ]
+        );
+
+        $this->assertEquals(
+            [
+                ['language' => 'en', 'synonyms' => ['laptop, notebook']],
+                ['language' => 'lt', 'synonyms' => ['telefonas, mobilusis']],
+            ],
+            $request->jsonSerialize()['synonyms']
+        );
+    }
+
+    public function testWithSynonymsReturnsNewInstance(): void
+    {
+        $request = new IndexCreateRequest(
+            ['en-US'],
+            [new FieldDefinition('name', FieldType::TEXT)]
+        );
+
+        $synonyms = [new SynonymConfiguration('en', [['laptop', 'notebook']])];
+        $updated = $request->withSynonyms($synonyms);
+
+        $this->assertNotSame($request, $updated);
+        $this->assertEquals([], $request->synonyms);
+        $this->assertEquals($synonyms, $updated->synonyms);
+    }
+
+    public function testThrowsExceptionForInvalidSynonymEntry(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Synonym at index 0 must be an instance of SynonymConfiguration.');
+
+        new IndexCreateRequest(
+            ['en-US'],
+            [new FieldDefinition('name', FieldType::TEXT)],
+            [['language' => 'en', 'synonyms' => [['laptop', 'notebook']]]]
         );
     }
 }

--- a/tests/V2/ValueObjects/Response/SynonymResponseTest.php
+++ b/tests/V2/ValueObjects/Response/SynonymResponseTest.php
@@ -109,6 +109,33 @@ class SynonymResponseTest extends TestCase
         );
     }
 
+    public function testFromArrayHandlesNonArraySynonymsWithoutTypeError(): void
+    {
+        $response = SynonymResponse::fromArray([
+            'language' => 'en',
+            'synonym_count' => 0,
+            'requires_reindex' => false,
+            'synonyms' => 'laptop, notebook',
+        ]);
+
+        $this->assertNull($response->synonyms);
+    }
+
+    public function testFromArrayDropsMalformedGroupsThatNormalizeToEmpty(): void
+    {
+        $response = SynonymResponse::fromArray([
+            'language' => 'en',
+            'synonym_count' => 1,
+            'requires_reindex' => false,
+            'synonyms' => [
+                'laptop, notebook',
+                123,
+            ],
+        ]);
+
+        $this->assertEquals([['laptop', 'notebook']], $response->synonyms);
+    }
+
     public function testFromArrayThrowsOnMissingLanguage(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -251,11 +278,12 @@ class SynonymResponseTest extends TestCase
             true
         );
 
-        // The fixture is the Solr-string GET shape and omits count/reindex.
-        $response = SynonymResponse::fromArray($fixture + [
+        // The fixture is the Solr-string GET shape and omits count/reindex;
+        // supply defaults that the fixture overrides if it ever gains them.
+        $response = SynonymResponse::fromArray(array_merge([
             'synonym_count' => count($fixture['synonyms']),
             'requires_reindex' => false,
-        ]);
+        ], $fixture));
 
         $this->assertEquals('en', $response->language);
         $this->assertEquals(3, $response->synonymCount);

--- a/tests/V2/ValueObjects/Response/SynonymResponseTest.php
+++ b/tests/V2/ValueObjects/Response/SynonymResponseTest.php
@@ -136,6 +136,20 @@ class SynonymResponseTest extends TestCase
         $this->assertEquals([['laptop', 'notebook']], $response->synonyms);
     }
 
+    public function testFromArrayTrimsArrayFormGroupsAndDropsNonStringElements(): void
+    {
+        $response = SynonymResponse::fromArray([
+            'language' => 'en',
+            'synonym_count' => 1,
+            'requires_reindex' => false,
+            'synonyms' => [
+                ['laptop ', ' notebook', 123],
+            ],
+        ]);
+
+        $this->assertEquals([['laptop', 'notebook']], $response->synonyms);
+    }
+
     public function testFromArrayThrowsOnMissingLanguage(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/V2/ValueObjects/Response/SynonymResponseTest.php
+++ b/tests/V2/ValueObjects/Response/SynonymResponseTest.php
@@ -150,6 +150,20 @@ class SynonymResponseTest extends TestCase
         $this->assertEquals([['laptop', 'notebook']], $response->synonyms);
     }
 
+    public function testFromArrayDropsEmptyTermsFromSolrStringGroups(): void
+    {
+        $response = SynonymResponse::fromArray([
+            'language' => 'en',
+            'synonym_count' => 1,
+            'requires_reindex' => false,
+            'synonyms' => [
+                'laptop, , notebook',
+            ],
+        ]);
+
+        $this->assertEquals([['laptop', 'notebook']], $response->synonyms);
+    }
+
     public function testFromArrayThrowsOnMissingLanguage(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/V2/ValueObjects/Response/SynonymResponseTest.php
+++ b/tests/V2/ValueObjects/Response/SynonymResponseTest.php
@@ -88,6 +88,27 @@ class SynonymResponseTest extends TestCase
         $this->assertEquals($synonyms, $response->synonyms);
     }
 
+    public function testFromArrayNormalizesSolrStringSynonymsIntoGroups(): void
+    {
+        $response = SynonymResponse::fromArray([
+            'language' => 'en',
+            'synonym_count' => 2,
+            'requires_reindex' => false,
+            'synonyms' => [
+                'laptop, notebook,computer',
+                'phone, mobile',
+            ],
+        ]);
+
+        $this->assertEquals(
+            [
+                ['laptop', 'notebook', 'computer'],
+                ['phone', 'mobile'],
+            ],
+            $response->synonyms
+        );
+    }
+
     public function testFromArrayThrowsOnMissingLanguage(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/V2/ValueObjects/Response/SynonymResponseTest.php
+++ b/tests/V2/ValueObjects/Response/SynonymResponseTest.php
@@ -244,23 +244,29 @@ class SynonymResponseTest extends TestCase
      */
     public function testMatchesOpenApiExampleResponse(): void
     {
-        $apiResponse = [
-            'language' => 'en',
-            'synonym_count' => 3,
-            'requires_reindex' => true,
-            'synonyms' => [
+        $fixture = json_decode(
+            (string) file_get_contents(
+                __DIR__ . '/../../../fixtures/openapi-examples/synonyms-ecommerce-en.json'
+            ),
+            true
+        );
+
+        // The fixture is the Solr-string GET shape and omits count/reindex.
+        $response = SynonymResponse::fromArray($fixture + [
+            'synonym_count' => count($fixture['synonyms']),
+            'requires_reindex' => false,
+        ]);
+
+        $this->assertEquals('en', $response->language);
+        $this->assertEquals(3, $response->synonymCount);
+        $this->assertEquals(
+            [
                 ['laptop', 'notebook', 'computer'],
                 ['phone', 'mobile', 'smartphone'],
                 ['shoes', 'footwear', 'sneakers'],
             ],
-        ];
-
-        $response = SynonymResponse::fromArray($apiResponse);
-
-        $this->assertEquals('en', $response->language);
-        $this->assertEquals(3, $response->synonymCount);
-        $this->assertTrue($response->requiresReindex);
-        $this->assertCount(3, $response->synonyms);
+            $response->synonyms
+        );
     }
 
     public function testJsonEncodeProducesValidJson(): void

--- a/tests/V2/ValueObjects/Synonym/SynonymConfigurationTest.php
+++ b/tests/V2/ValueObjects/Synonym/SynonymConfigurationTest.php
@@ -184,6 +184,7 @@ class SynonymConfigurationTest extends TestCase
             ],
         ]);
 
+        $this->assertNotNull($config);
         $this->assertEquals('en', $config->language);
         $this->assertEquals(
             [
@@ -192,6 +193,18 @@ class SynonymConfigurationTest extends TestCase
             ],
             $config->synonyms
         );
+    }
+
+    public function testFromApiResponseReturnsNullForEmptySynonyms(): void
+    {
+        $this->assertNull(SynonymConfiguration::fromApiResponse([
+            'language' => 'en',
+            'synonyms' => [],
+        ]));
+
+        $this->assertNull(SynonymConfiguration::fromApiResponse([
+            'language' => 'en',
+        ]));
     }
 
     public function testToArrayReturnsJsonSerializeOutput(): void
@@ -398,10 +411,10 @@ class SynonymConfigurationTest extends TestCase
 
     public function testAcceptsManySynonymGroups(): void
     {
-        $synonyms = [];
-        for ($i = 0; $i < 100; $i++) {
-            $synonyms[] = ["term{$i}a", "term{$i}b"];
-        }
+        $synonyms = array_map(
+            fn(int $i): array => ["term{$i}a", "term{$i}b"],
+            range(0, 99)
+        );
 
         $config = new SynonymConfiguration('en', $synonyms);
 

--- a/tests/V2/ValueObjects/Synonym/SynonymConfigurationTest.php
+++ b/tests/V2/ValueObjects/Synonym/SynonymConfigurationTest.php
@@ -138,7 +138,7 @@ class SynonymConfigurationTest extends TestCase
         new SynonymConfiguration('en', [['   ', 'laptop']]);
     }
 
-    public function testJsonSerializeReturnsCorrectStructure(): void
+    public function testJsonSerializeReturnsSolrFormatStrings(): void
     {
         $synonyms = [
             ['laptop', 'notebook'],
@@ -149,10 +149,49 @@ class SynonymConfigurationTest extends TestCase
 
         $expected = [
             'language' => 'en',
-            'synonyms' => $synonyms,
+            'synonyms' => [
+                'laptop, notebook',
+                'phone, mobile',
+            ],
         ];
 
         $this->assertEquals($expected, $config->jsonSerialize());
+    }
+
+    public function testRejectsCommaInSynonymTerm(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not contain "," or "=>"');
+
+        new SynonymConfiguration('en', [['laptop, notebook', 'computer']]);
+    }
+
+    public function testRejectsExplicitMappingArrowInSynonymTerm(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not contain "," or "=>"');
+
+        new SynonymConfiguration('en', [['laptop => notebook', 'computer']]);
+    }
+
+    public function testFromApiResponseParsesSolrStringsIntoGroups(): void
+    {
+        $config = SynonymConfiguration::fromApiResponse([
+            'language' => 'en',
+            'synonyms' => [
+                'laptop, notebook,computer',
+                'phone, mobile',
+            ],
+        ]);
+
+        $this->assertEquals('en', $config->language);
+        $this->assertEquals(
+            [
+                ['laptop', 'notebook', 'computer'],
+                ['phone', 'mobile'],
+            ],
+            $config->synonyms
+        );
     }
 
     public function testToArrayReturnsJsonSerializeOutput(): void
@@ -242,7 +281,13 @@ class SynonymConfigurationTest extends TestCase
         $decoded = json_decode($json, true);
 
         $this->assertEquals('en', $decoded['language']);
-        $this->assertEquals($synonyms, $decoded['synonyms']);
+        $this->assertEquals(
+            [
+                'laptop, notebook, computer',
+                'phone, mobile, smartphone',
+            ],
+            $decoded['synonyms']
+        );
     }
 
     public function testChainedWithMethods(): void
@@ -313,9 +358,9 @@ class SynonymConfigurationTest extends TestCase
         $expected = [
             'language' => 'en',
             'synonyms' => [
-                ['laptop', 'notebook', 'computer'],
-                ['phone', 'mobile', 'smartphone'],
-                ['shoes', 'footwear', 'sneakers'],
+                'laptop, notebook, computer',
+                'phone, mobile, smartphone',
+                'shoes, footwear, sneakers',
             ],
         ];
 

--- a/tests/fixtures/openapi-examples/synonyms-ecommerce-en.json
+++ b/tests/fixtures/openapi-examples/synonyms-ecommerce-en.json
@@ -1,8 +1,8 @@
 {
     "language": "en",
     "synonyms": [
-        ["laptop", "notebook", "computer"],
-        ["phone", "mobile", "smartphone"],
-        ["shoes", "footwear", "sneakers"]
+        "laptop, notebook, computer",
+        "phone, mobile, smartphone",
+        "shoes, footwear, sneakers"
     ]
 }


### PR DESCRIPTION
[BRD-804](https://invertus.atlassian.net/browse/BRD-804)

<!-- Briefly explain the purpose of this PR in 1-2 sentences -->
Aligns synonym handling with the backend's Solr equivalence-string format — groups are serialized to/from Solr strings ("laptop, notebook, computer") at the API boundary while the SDK exposes them as term arrays internally — and lets IndexCreateRequest carry optional per-language synonyms so they're seeded at index creation. SDK-only: the consumer-side changes (V2IndexManager, SynonymPusher, VersionSwitchForNewIndexJob, synonym search-type) live in brad-app/brad-search and are tracked in separate PRs.

## QA Checklist Labels

- [x] Bug fix? <!-- Maps to "bug" label -->
- [ ] New feature? <!-- Maps to "feature" label -->
- [ ] Improvement? <!-- Maps to "improvement" label -->
- [x] Technical debt? <!-- Maps to "debt" label -->
- [ ] Reusable? <!-- Maps to "reuse" label -->
- [ ] Covered by tests? <!-- Maps to "tested" label -->


https://github.com/user-attachments/assets/fc6eb057-5688-4897-a9e6-2ea926f47dd8



[BRD-804]: https://invertus.atlassian.net/browse/BRD-804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ