### PR TITLE
BRD-1127: Rewrite CLAUDE.md around V2, fixture parity, locale contract, quality gates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,103 +1,127 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code when working with code in this repository (`bradsearch/search-sync-sdk`). Facts below verified against the working tree as of 2026-07-03.
 
-## Development Commands
+## What this is
+
+Pure-PHP (>= 8.4), zero runtime composer deps, client library for the Brad Search synchronization/admin HTTP API. Every payload it emits is an API contract: the server's OpenAPI v2 spec defines the shape, this repo's fixtures assert it byte-for-byte, and downstream consumers depend on it.
+
+## V1 / V2 — two generations coexist
+
+**V2 is the current, active surface. Center new work here.** V1 is legacy and stays alive only while customers remain on it — neither generation may be deleted.
+
+| | V1 (legacy) | V2 (current) |
+|---|---|---|
+| Facade | `src/SynchronizationApiSdk.php` | `src/SyncV2Sdk.php` |
+| Config | `src/Config/SyncConfig.php` | `src/Config/SyncConfigV2.php` (appId **must be a UUID**; apiUrl, token, optional `targetIndex`) |
+| Endpoints | `/api/v1/sync/...` | `/api/v2/applications/{appId}/...` |
+| Payload style | raw arrays + `src/Validators/DataValidator.php` | **strict immutable readonly ValueObjects** in `src/V2/ValueObjects/` (BulkOperations, Index, Normalize, Product, Response, Search, SearchSettings, Synonym, Common) with constructor validation, builders, and `jsonSerialize()` asserted against fixtures |
+| Adapters | `PrestaShopAdapter`, `MagentoAdapter` | `PrestaShopAdapterV2`, `MagentoAdapterV2`, `ShopifyAdapter` (V2-only) |
+
+Also: `src/AdminSdk.php` + `src/Client/AdminHttpClient.php` for `/api/v2/admin/indices` (raw physical index list/delete).
+
+**A field/feature that both generations expose must land twice** — once in the V1 array path, once in the V2 ValueObject path. Confirm with the owner before duplicating; some features (synonyms, search settings, alias versioning) are V2-only. Which generation a given customer uses is decided server-side by the consuming application, not here.
+
+The V2 design contract lives in `tasks/prd-v2-valueobjects.md` — read it before changing VO conventions (immutability, `with*()` methods, builders, exact OpenAPI alignment).
+
+## OpenAPI golden-fixture parity (the centerpiece discipline)
+
+`tests/fixtures/openapi-examples/*.json` are not sample data — they ARE the cross-repo contract test:
+
+```
+tests/fixtures/openapi-examples/
+├── index-create-darbo-drabuziai.json
+├── bulk-operations-darbo-drabuziai.json
+├── configuration-advanced.json
+├── search-configuration-request.json
+├── search-settings-full.json
+└── synonyms-ecommerce-en.json
+```
+
+Each file is copied verbatim from an example payload in the server's OpenAPI v2 spec. `tests/V2/ApiPayloadVerificationTest.php` builds the same payload through the V2 ValueObjects/builders and asserts `jsonSerialize()` equals the decoded fixture — exact byte-level/structural alignment, not "close enough." `tests/V2/DarboDrabuziaiWorkflowTest.php` chains the fixtures into a full end-to-end simulation (create index v1 → configure → bulk-sync → create index v2 → sync → activate v2 → verify → cleanup, plus a rollback scenario).
+
+**If you change a V2 payload shape**, do this in lockstep, in one PR (after the server-side API change lands first):
+1. Confirm the field/shape exists in the server's OpenAPI v2 spec first — never invent a shape SDK-side.
+2. Update the ValueObject in `src/V2/ValueObjects/<area>/`.
+3. Update the matching builder and `with*()` methods.
+4. Update the affected fixture — copied from the server's OpenAPI spec, never hand-authored from memory.
+5. Update `ApiPayloadVerificationTest` (and `DarboDrabuziaiWorkflowTest` if index-create/bulk-operations shape moved).
+6. Decide explicitly whether the V1 side also needs the change.
+7. Quality-gate triple green (below).
+
+**Failure smell**: if a fixture test fails, do not "fix" it by editing the fixture to match your output. The fixture mirrors the API spec. Either copy the spec's new example verbatim, or fix your VO — the fixture is never adjusted just to silence a test.
+
+## Locale-suffix contract
+
+Documented in `src/Adapters/README.md` ("Locale Handling"):
+
+1. The first locale in an adapter's constructor array is the default locale.
+2. Default-locale fields are unsuffixed: `name`, `description`.
+3. Every other locale gets a suffixed field: `name_lt-LT`, `description_en-US`.
+4. Fallback: if a product is missing the default locale's value, adapters fall back to the first available locale.
+
+Enforced by `src/V2/ValueObjects/Common/LocalizedField.php`, which builds `<baseName>_<locale>` and validates the locale against `^[a-z]{2}(-[A-Z]{2})?$` (region part is optional — `lt` is as valid as `lt-LT`), throwing `InvalidLocaleException` otherwise.
+
+Getting this wrong does not error — it silently breaks search relevance in one language (fields land under the wrong name; the engine's per-language analyzers never see them). Treat any locale-touching diff as high-risk; cover both the unsuffixed default and the suffixed path with tests.
+
+**Known debt**: V1's embeddable-fields builder hardcodes the locale pair — `src/SynchronizationApiSdk.php:348-349` (`$locales = ['en-US', 'lt-LT'];`). This blocks V1 customers outside that pair. It is a known gap; fixing it needs its own ticket (changes V1 index mappings) — do not fix it as a drive-by.
+
+## Development commands
 
 ### Testing
 ```bash
-# Run all tests
-vendor/bin/phpunit
+vendor/bin/phpunit --testdox
+```
+PHPUnit 11. `phpunit.xml` sets `failOnRisky` + `failOnWarning` — warnings fail the build.
 
-# Run tests with coverage
-vendor/bin/phpunit --coverage-html coverage
+### Quality-gate triple — all three required, every PR
 
-# Run a specific test
-vendor/bin/phpunit tests/Adapters/PrestaShopAdapterTest.php
+This is exactly what CI runs (`.github/workflows/tests.yml`: a `tests` job and a `code-quality` job, PHP 8.4, extensions json/curl/bcmath):
+
+```bash
+vendor/bin/phpunit --testdox     # expect all green
+vendor/bin/phpstan analyse       # level 4, src/ only (phpstan.neon); expect "[OK] No errors"
+vendor/bin/phpcs src tests       # PSR-12 (phpcs.xml); expect empty output / exit 0
 ```
 
-### Code Quality
+`laravel/pint` is in require-dev but NOT wired into CI — phpcs is the authority. No Makefile, no docker-compose, no `.env`; tests are fully offline (HTTP is mocked).
+
+### Install
 ```bash
-# Run PHPStan static analysis
-vendor/bin/phpstan analyse
-
-# Run PHP CodeSniffer
-vendor/bin/phpcs src tests
-
-# Install dependencies
 composer install
-
-# Update dependencies
 composer update
 ```
 
-## Code Architecture
+## Code architecture
 
-### Core SDK Structure
-The PHP SDK for Brad Search synchronization is organized into a modular architecture:
+### Key components
+- **`SynchronizationApiSdk`** (V1) / **`SyncV2Sdk`** (V2) — main facades.
+- **Field Configuration** (`src/Models/`) — `FieldConfig`, `FieldConfigBuilder`, `FieldType` enum (V1).
+- **ValueObjects** (`src/V2/ValueObjects/`) — V2 payload types with constructor validation and builders.
+- **Validation** (`src/Validators/DataValidator.php`) — V1 client-side validation before any API call.
+- **HTTP** (`src/Client/`) — `HttpClient` (V1), `AdminHttpClient` (admin API).
+- **Adapters** (`src/Adapters/`) — `PrestaShopAdapter`/`PrestaShopAdapterV2`, `MagentoAdapter`/`MagentoAdapterV2` (GraphQL-fed via `src/Magento/`), `ShopifyAdapter` (V2-only).
 
-- **`SynchronizationApiSdk`** - Main SDK class providing the public API for index management and product synchronization
-- **Field Configuration System** - Type-safe field definitions using PHP enums and configuration builders
-- **Validation Layer** - Comprehensive data validation against field configurations before API calls
-- **HTTP Client** - cURL-based client with error handling and authentication
-- **Exception Hierarchy** - Typed exceptions for different error scenarios
+### targetIndex / alias semantics
 
-### Key Components
+The API exposes versioned physical indices behind an alias named after the appId. `SyncConfigV2->targetIndex` defaults to `null`, so bulk ops normally hit the alias (the LIVE index). During a zero-downtime reindex, construct a second `SyncConfigV2` with `targetIndex` set to the new versioned index so bulk-loading targets the inactive version while search keeps serving the old one; only `activateIndexVersion()` flips traffic. If a sync appears to do nothing, check whether it wrote to a non-active version via `getIndexInfo()`. `AdminSdk` lists raw physical indices, not aliases.
 
-#### SynchronizationApiSdk (src/SynchronizationApiSdk.php)
-Main entry point providing methods:
-- `createIndex()` / `deleteIndex()` - Index management
-- `sync()` / `syncBulk()` - Product synchronization (single and batch)
-- `copyIndex()` - Index replication
-- `deleteProductsBulk()` - Bulk product deletion
-- `validateProduct()` / `validateProducts()` - Data validation without syncing
+### Price correctness (recurring bug class)
 
-#### Field Configuration (src/Models/)
-- **`FieldConfig`** - Individual field configuration with type and attributes
-- **`FieldConfigBuilder`** - Helper for building common field configurations
-- **`FieldType` enum** - Defines supported field types (TEXT_KEYWORD, HIERARCHY, VARIANTS, etc.)
+- **Shopify money math is bcmath-only, mandatorily**: `ShopifyAdapter` refuses to construct without `bccomp` and compares prices with `bccomp(..., 2)`. Never replace bcmath comparisons with float `>`/`==`.
+- bcmath is Shopify-only — `PrestaShopAdapterV2`/`MagentoAdapterV2` use native numerics with explicit zero-price guards. This asymmetry is historical, not principled; keep zero-price guards intact if you touch non-Shopify price code.
+- Zero/empty prices are legitimate inputs from every platform — treat as "no discount", never divide by them.
 
-#### Validation System (src/Validators/)
-- **`DataValidator`** - Validates product data against field configuration
-- Supports all field types including hierarchical categories, variants with attributes, and URL validation
-- Provides detailed error reporting
+### Who consumes this SDK
 
-#### HTTP Layer (src/Client/)
-- **`HttpClient`** - Handles API communication with authentication, timeouts, and error handling
-- Supports all HTTP methods (GET, POST, PUT, DELETE) with JSON encoding
+- The primary consumer is a **Laravel application**, resolving `bradsearch/search-sync-sdk` from packagist.org (no `repositories` block). Local dev uses a composer path-repository symlink to your checkout.
+- The **PrestaShop module** does NOT depend on this SDK — it targets PHP >= 7.1 and owns its own product transformation.
+- Releases are git tags (`vMAJOR.MINOR.PATCH`); there is no publish workflow in this repo.
 
-### API Endpoints
-The SDK communicates with these endpoints:
-- `DELETE /api/v1/sync/{index}` - Delete index
-- `PUT /api/v1/sync/` - Create index with field configuration
-- `POST /api/v1/sync/` - Bulk sync products
-- `POST /api/v1/sync/reindex` - Copy/reindex operations
-- `POST /api/v1/sync/delete-products` - Bulk delete products
+## Dependencies
 
-### Field Types Supported
-- `TEXT_KEYWORD` - Full-text search with keyword matching
-- `TEXT` - Full-text search only
-- `KEYWORD` - Exact keyword matching
-- `HIERARCHY` - Hierarchical categories (e.g., "Clothing > T-Shirts > Premium")
-- `VARIANTS` - Product variants with configurable attributes
-- `NAME_VALUE_LIST` - Key-value pairs (features, specifications)
-- `IMAGE_URL` - Image URLs object with size keys
-- `URL` - Regular URLs with validation
-- `FLOAT`, `INTEGER`, `DOUBLE` - Numeric types
-
-### Data Processing
-- **Field Filtering** - Only configured fields are sent to API
-- **Batch Processing** - Large datasets automatically chunked (default 100 items per batch)
-- **Validation First** - All products validated before any API calls
-- **Embeddable Fields** - Support for localized fields with configurable locales
-
-### PrestaShop Integration
-The SDK includes a PrestaShop adapter (`src/Adapters/PrestaShopAdapter.php`) for e-commerce platform integration, handling product data mapping and synchronization specific to PrestaShop's data structure.
-
-### Dependencies
-- **PHP 8.4+** - Uses modern PHP features (readonly properties, enums, constructor property promotion)
-- **ext-json** - JSON encoding/decoding
-- **ext-curl** - HTTP client functionality
-- **PHPUnit** - Testing framework
-- **PHPStan** - Static analysis
-- **PHP CodeSniffer** - Code style enforcement
+- **PHP >= 8.4** — readonly properties, enums, constructor property promotion.
+- **ext-json** — JSON encoding/decoding.
+- **ext-curl** — HTTP client.
+- **ext-bcmath** — required for Shopify decimal-safe price comparisons (`ShopifyAdapter`).
+- **PHPUnit 11**, **PHPStan** (level 4), **PHP CodeSniffer** (PSR-12) — dev-only, see quality-gate triple above.


### PR DESCRIPTION
## What
Rewrite `CLAUDE.md` for brad-search-php-sdk.

## Why
Part of BRD-1127 (CLAUDE.md refresh across all repos). The file was fossilized at the V1 era and presented V1-only content as canonical.

Jira: https://invertus.atlassian.net/browse/BRD-1127

## Changes
- Recenter on V2 / ValueObjects with a V1/V2 comparison table; shared features must land in both generations.
- Add OpenAPI golden-fixture parity discipline (`tests/fixtures/openapi-examples/`, `ApiPayloadVerificationTest`) and the "never edit the fixture to silence a test" rule.
- Add the locale-suffix contract.
- Add the quality-gate triple (phpunit / phpstan level 4 / phpcs PSR-12), verified against `.github/workflows/tests.yml`.
- Add `ext-bcmath` to PHP requirements (Shopify `bccomp` money math).

All requirements, gate commands, and fixture paths verified against the repo.

## Testing
Docs-only change; no code affected.
