### PR TITLE
BRD-1150: add categoriesFlat field with split category levels

### DIFF
--- a/src/Adapters/AdapterUtils.php
+++ b/src/Adapters/AdapterUtils.php
@@ -161,4 +161,38 @@ final class AdapterUtils
             'exception' => $exception,
         ];
     }
+
+    /**
+     * Split hierarchical category paths into their unique level values,
+     * preserving first-seen order.
+     *
+     * ["Store > Summer > Men", "Store > Spring"] -> ["Store", "Summer", "Men", "Spring"]
+     *
+     * Feeds the search-only categoriesFlat field: each level is analyzed from
+     * position 0, so synonym and stemmed matching reach every level of a long
+     * path. Only ' > ' with surrounding spaces delimits levels — a bare '>'
+     * inside a category name is not split.
+     *
+     * @param array<mixed> $paths
+     * @return array<string>
+     */
+    public static function splitCategoryLevels(array $paths): array
+    {
+        $levels = [];
+
+        foreach ($paths as $path) {
+            if (!is_string($path) || $path === '') {
+                continue;
+            }
+
+            foreach (explode(' > ', $path) as $level) {
+                $level = trim($level);
+                if ($level !== '' && !in_array($level, $levels, true)) {
+                    $levels[] = $level;
+                }
+            }
+        }
+
+        return $levels;
+    }
 }

--- a/src/Adapters/MagentoAdapterV2.php
+++ b/src/Adapters/MagentoAdapterV2.php
@@ -148,6 +148,11 @@ class MagentoAdapterV2
         $categories = $this->buildHierarchicalCategories($product);
         if (!empty($categories)) {
             $additionalFields["categories_{$locale}"] = $categories;
+
+            $flatCategories = AdapterUtils::splitCategoryLevels($categories);
+            if (!empty($flatCategories)) {
+                $additionalFields["categoriesFlat_{$locale}"] = $flatCategories;
+            }
         }
 
         $categoryDefault = $this->extractDefaultCategory($product);

--- a/src/Adapters/PrestaShopAdapterV2.php
+++ b/src/Adapters/PrestaShopAdapterV2.php
@@ -135,6 +135,7 @@ class PrestaShopAdapterV2
 
         // Handle categories
         $this->extractCategories($additionalFields, $product);
+        $this->addFlatCategories($additionalFields);
         $this->extractCategoryDefault($additionalFields, $product);
 
         // Handle product URLs
@@ -543,6 +544,32 @@ class PrestaShopAdapterV2
         }
 
         $this->extractCategory($product[$categoryFieldName], $categoryFieldName, $result);
+    }
+
+    /**
+     * Add a categoriesFlat_{locale} field per collected categories_{locale} field.
+     *
+     * @param array<string, mixed> $result
+     */
+    private function addFlatCategories(array &$result): void
+    {
+        $flatFields = [];
+
+        foreach ($result as $key => $paths) {
+            if (!str_starts_with($key, 'categories_') || !is_array($paths)) {
+                continue;
+            }
+
+            $locale = substr($key, strlen('categories_'));
+            $levels = AdapterUtils::splitCategoryLevels($paths);
+            if (!empty($levels)) {
+                $flatFields["categoriesFlat_{$locale}"] = $levels;
+            }
+        }
+
+        foreach ($flatFields as $key => $levels) {
+            $result[$key] = $levels;
+        }
     }
 
     /**

--- a/src/Adapters/ShopifyAdapter.php
+++ b/src/Adapters/ShopifyAdapter.php
@@ -186,6 +186,11 @@ class ShopifyAdapter
             if (!empty($localeCategories)) {
                 $fields["categories_{$locale}"] = $localeCategories;
             }
+            // Taxonomy only: tags are already flat single values with nothing to split.
+            $flatCategories = AdapterUtils::splitCategoryLevels([$categoryDefault]);
+            if (!empty($flatCategories)) {
+                $fields["categoriesFlat_{$locale}"] = $flatCategories;
+            }
 
             $localeProductType = $this->translated($localeTranslations, 'product_type')
                 ?? ($locale === $primaryLocale ? $nativeProductType : '');
@@ -235,6 +240,8 @@ class ShopifyAdapter
         string $primaryLocale,
     ): array {
         $collections = $this->resolveCollectionTitles($productCollections, $primaryLocale, $primaryLocale);
+        // Taxonomy only: tags are already flat single values with nothing to split.
+        $flatCategories = AdapterUtils::splitCategoryLevels([$categoryDefault]);
 
         return array_filter([
             'name' => $title,
@@ -242,6 +249,7 @@ class ShopifyAdapter
             'brand' => $brand !== '' ? $brand : null,
             'categoryDefault' => $categoryDefault,
             'categories' => $this->buildCategories($categoryDefault, $this->extractTags($product)),
+            'categoriesFlat' => !empty($flatCategories) ? $flatCategories : null,
             'productType' => $nativeProductType !== '' ? $nativeProductType : null,
             'productUrl' => $productUrl !== '' ? $productUrl : null,
             'collections' => !empty($collections) ? $collections : null,

--- a/tests/Adapters/AdapterUtilsTest.php
+++ b/tests/Adapters/AdapterUtilsTest.php
@@ -198,4 +198,48 @@ class AdapterUtilsTest extends TestCase
         $this->assertSame('invalid_structure', $result['type']);
         $this->assertNull($result['exception']);
     }
+
+    public function testSplitCategoryLevelsDedupesAcrossPaths(): void
+    {
+        $result = AdapterUtils::splitCategoryLevels([
+            'Store > Summer > Men > T-Shirts',
+            'Store > Spring > Men > Shirtlings',
+        ]);
+
+        $this->assertSame(
+            ['Store', 'Summer', 'Men', 'T-Shirts', 'Spring', 'Shirtlings'],
+            $result
+        );
+    }
+
+    public function testSplitCategoryLevelsSingleLevelPath(): void
+    {
+        $this->assertSame(['Women'], AdapterUtils::splitCategoryLevels(['Women']));
+    }
+
+    public function testSplitCategoryLevelsEmptyInput(): void
+    {
+        $this->assertSame([], AdapterUtils::splitCategoryLevels([]));
+    }
+
+    public function testSplitCategoryLevelsRequiresSpacedDelimiter(): void
+    {
+        $result = AdapterUtils::splitCategoryLevels(['A>B > C']);
+
+        $this->assertSame(['A>B', 'C'], $result);
+    }
+
+    public function testSplitCategoryLevelsTrimsAndDropsEmptySegments(): void
+    {
+        $result = AdapterUtils::splitCategoryLevels(['Men >  > Shoes ', '']);
+
+        $this->assertSame(['Men', 'Shoes'], $result);
+    }
+
+    public function testSplitCategoryLevelsSkipsNonStringValues(): void
+    {
+        $result = AdapterUtils::splitCategoryLevels([null, 42, 'Men > Shoes']);
+
+        $this->assertSame(['Men', 'Shoes'], $result);
+    }
 }

--- a/tests/Adapters/MagentoAdapterV2Test.php
+++ b/tests/Adapters/MagentoAdapterV2Test.php
@@ -916,6 +916,28 @@ class MagentoAdapterV2Test extends TestCase
 
     // --- Helpers ---
 
+    public function testCategoriesFlatContainsUniqueLevels(): void
+    {
+        $product = $this->adapter->transformProduct($this->buildMinimalProduct([
+            'categories' => [
+                ['id' => '2', 'name' => 'Tools', 'path' => '1/2', 'level' => 1],
+                ['id' => '5', 'name' => 'Drills', 'path' => '1/2/5', 'level' => 2],
+            ],
+        ]));
+        $serialized = $product->jsonSerialize();
+
+        $this->assertSame(['Tools', 'Tools > Drills'], $serialized['categories_lt-LT']);
+        $this->assertSame(['Tools', 'Drills'], $serialized['categoriesFlat_lt-LT']);
+    }
+
+    public function testNoCategoriesFlatWithoutCategories(): void
+    {
+        $product = $this->adapter->transformProduct($this->buildMinimalProduct());
+        $serialized = $product->jsonSerialize();
+
+        $this->assertArrayNotHasKey('categoriesFlat_lt-LT', $serialized);
+    }
+
     /**
      * @param array<string, mixed> $overrides
      * @return array<string, mixed>

--- a/tests/Adapters/PrestaShopAdapterV2Test.php
+++ b/tests/Adapters/PrestaShopAdapterV2Test.php
@@ -140,6 +140,59 @@ class PrestaShopAdapterV2Test extends TestCase
         $this->assertEquals('Springa', $product->additionalFields['brand_en-US']);
         $this->assertEquals('http://prestashop/sneakers/1807-sneakers.html', $product->additionalFields['productUrl_en-US']);
         $this->assertEquals(['Men', 'Men > Shoes'], $product->additionalFields['categories_en-US']);
+        $this->assertEquals(['Men', 'Shoes'], $product->additionalFields['categoriesFlat_en-US']);
+    }
+
+    public function testTransformAddsFlatCategoryLevelsPerLocale(): void
+    {
+        $product = $this->getMinimalProductData('1807', 'SKU-123');
+        $product['categories'] = [
+            'lvl2' => [
+                [
+                    'remoteId' => '148',
+                    'localizedValues' => [
+                        'path' => [
+                            'en-US' => 'Store > Summer > Men > T-Shirts',
+                            'lt-LT' => 'Parduotuvė > Vasara > Vyrai > Marškinėliai',
+                        ],
+                    ],
+                ],
+            ],
+            'lvl3' => [
+                [
+                    'remoteId' => '163',
+                    'localizedValues' => [
+                        'path' => [
+                            'en-US' => 'Store > Spring > Men > Shirtlings',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->adapter->transform(['products' => [$product]]);
+        $fields = $result['products'][0]->additionalFields;
+
+        $this->assertSame(
+            ['Store > Summer > Men > T-Shirts', 'Store > Spring > Men > Shirtlings'],
+            $fields['categories_en-US']
+        );
+        $this->assertSame(
+            ['Store', 'Summer', 'Men', 'T-Shirts', 'Spring', 'Shirtlings'],
+            $fields['categoriesFlat_en-US']
+        );
+        $this->assertSame(
+            ['Parduotuvė', 'Vasara', 'Vyrai', 'Marškinėliai'],
+            $fields['categoriesFlat_lt-LT']
+        );
+    }
+
+    public function testNoFlatCategoriesWithoutCategories(): void
+    {
+        $result = $this->adapter->transform($this->getMinimalValidProduct());
+        $fields = $result['products'][0]->additionalFields;
+
+        $this->assertArrayNotHasKey('categoriesFlat_en-US', $fields);
     }
 
     public function testTransformProductWithMultipleLocales(): void

--- a/tests/Adapters/ShopifyAdapterTest.php
+++ b/tests/Adapters/ShopifyAdapterTest.php
@@ -893,6 +893,47 @@ class ShopifyAdapterTest extends TestCase
         $this->assertArrayNotHasKey('productType', $c);
     }
 
+    public function testCategoriesFlatContainsTaxonomyLevelsOnly(): void
+    {
+        $taxProduct = $this->makeProduct('gid://shopify/Product/1', 'Tee', 'Desc', 'BrandX', 'Shoes');
+        $taxProduct['node']['category'] = [
+            'id' => 'gid://shopify/TaxonomyCategory/aa-1-13-8',
+            'name' => 'Shirts',
+            'fullName' => 'Apparel & Accessories > Clothing > Shirts',
+        ];
+        $taxProduct['node']['tags'] = ['summer', 'cotton'];
+
+        // No taxonomy: tags alone are already flat single values — nothing to split.
+        $noTaxProduct = $this->makeProduct('gid://shopify/Product/2', 'Ski', 'Desc', 'BrandX', 'Winter');
+        $noTaxProduct['node']['category'] = null;
+        $noTaxProduct['node']['tags'] = ['cold'];
+
+        $result = $this->adapter->transform($this->makeShopifyResponse([$taxProduct, $noTaxProduct]));
+        [$a, $b] = $result['products'];
+
+        $this->assertSame(['Apparel & Accessories', 'Clothing', 'Shirts'], $a['categoriesFlat']);
+        $this->assertNotContains('summer', $a['categoriesFlat']);
+        $this->assertArrayNotHasKey('categoriesFlat', $b);
+    }
+
+    public function testCategoriesFlatIsLocaleSuffixedInLocaleMode(): void
+    {
+        $product = $this->makeProduct('gid://shopify/Product/1', 'Tee', 'Desc', 'BrandX', 'Shoes');
+        $product['node']['category'] = [
+            'id' => 'gid://shopify/TaxonomyCategory/aa-1-13-8',
+            'name' => 'Shirts',
+            'fullName' => 'Apparel & Accessories > Clothing > Shirts',
+        ];
+        $product['node']['tags'] = ['summer'];
+
+        $result = $this->adapter->transform($this->makeShopifyResponse([$product], 'en'), ['en', 'lt']);
+        $p = $result['products'][0];
+
+        $this->assertSame(['Apparel & Accessories', 'Clothing', 'Shirts'], $p['categoriesFlat_en']);
+        $this->assertSame(['Apparel & Accessories', 'Clothing', 'Shirts'], $p['categoriesFlat_lt']);
+        $this->assertNotContains('summer', $p['categoriesFlat_en']);
+    }
+
     public function testMalformedCategoryFieldEmitsProductTypeAsOwnField(): void
     {
         $cases = [


### PR DESCRIPTION
## Summary

Synonym matching never reaches a leaf category today: synonyms need an exact value match against the stored path string, and a leaf like `Sneakers` can never equal `"Women > Shoes > Sneakers"`.

Each adapter now also emits a **`categoriesFlat_{locale}`** field: the unique level values of every category path, split on ` > `. Every level becomes an exact, independently-analyzed value that synonyms and keyword/exact clauses can hit.

The field is **search-only**. `categories` and `categoryDefault` are byte-for-byte untouched, so filter aggregations and the storefront category tree do not change. Appending levels into `categories` itself was tested on a real index and rejected: level values dominate the top-50 facet buckets and pollute the filter sidebar — evidence on [BRD-1150](https://invertus.atlassian.net/browse/BRD-1150).

## What changed

- `AdapterUtils::splitCategoryLevels()` — shared helper: split on ` > ` (space-padded only, so a bare `>` inside a category name is not a delimiter), trim, dedupe preserving first-seen order.
- `PrestaShopAdapterV2` — emits `categoriesFlat_{locale}` per collected `categories_{locale}`. Covers **PrestaShop and WooCommerce** (brad-app routes WooCommerce through this adapter in V2).
- `MagentoAdapterV2` — same, from its hierarchical paths.
- `ShopifyAdapter` — splits the taxonomy `fullName` only, in both locale and plain modes; tags are excluded because they are already flat single values.

Example: `["Store > Summer > Men > T-Shirts", "Store > Spring > Men > Shirtlings"]` → `categoriesFlat` = `["Store", "Summer", "Men", "T-Shirts", "Spring", "Shirtlings"]`.

## Deploy notes (corrected after local end-to-end test)

- Safe to merge and ship independently: `DataValidator` skips fields absent from the field configuration, so the new field is inert until brad-app defines it (Invertus/brad-app#538).
- **The transformation runs at collect time only.** `sync:reindex-applications` and `sync:resync-applications` both replay stored `product_sync_operations` payloads without re-running the adapters — a reindex alone does NOT backfill this field. The data backfill happens via the first full platform sync after the SDK bump: checksums are computed over the transformed product, so every product's checksum changes and the sync rewrites all stored payloads and documents.
- Verified locally end-to-end with brad-app#538: adapters emit correct levels, sidebar facets stay byte-identical, and exact-value leaf matching goes from impossible (`categories.keyword == 'sneakers'` → 0 docs) to working (`categoriesFlat.keyword == 'sneakers'` → 122 docs) — the exact surface synonym matching uses.

## Testing

- 12 new tests: helper edge cases (multi-path dedupe, single-level path, spaced-delimiter-only splitting, whitespace, non-string values) plus per-adapter coverage asserting `categoriesFlat` content and that `categories`/`categoryDefault` stay unchanged.
- Full suite green: 1614 tests, 4367 assertions. PHPStan level 4 clean.
- Pint not applied: the touched files already fail `pint --test` on `main` with the same fixers, so reformatting would add unrelated churn.

Confidence: 92%

## Needs human verification

- Synonym→leaf matching end-to-end needs a synonym configured on staging after the full rollout (SDK bump + brad-app presets + reindex + one full sync) — that check is BRD-1150's staging acceptance, not this PR.

[BRD-1150]: https://invertus.atlassian.net/browse/BRD-1150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ